### PR TITLE
Implemented entity_autocomplete_aa & used it to fix homepage advanced search box

### DIFF
--- a/config/core.entity_form_display.node.work.default.yml
+++ b/config/core.entity_form_display.node.work.default.yml
@@ -37,6 +37,7 @@ dependencies:
     - image
     - inline_entity_form
     - link
+    - tagify
     - text
 third_party_settings:
   field_group:
@@ -141,14 +142,18 @@ bundle: work
 mode: default
 content:
   field_author:
-    type: entity_reference_autocomplete_tags
+    type: tagify_entity_reference_autocomplete_widget
     weight: 6
     region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
-      size: 60
       placeholder: ''
+      suggestions_dropdown: 1
+      show_entity_id: 0
+      show_info_label: 0
+      info_label: ''
+      parent_selection: 1
     third_party_settings: {  }
   field_category:
     type: options_buttons
@@ -171,24 +176,32 @@ content:
       preview_image_style: small_square
     third_party_settings: {  }
   field_cover_artist:
-    type: entity_reference_autocomplete_tags
+    type: tagify_entity_reference_autocomplete_widget
     weight: 7
     region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
-      size: 60
       placeholder: ''
+      suggestions_dropdown: 1
+      show_entity_id: 0
+      show_info_label: 0
+      info_label: ''
+      parent_selection: 1
     third_party_settings: {  }
   field_fandom2:
-    type: entity_reference_autocomplete_tags
+    type: tagify_entity_reference_autocomplete_widget
     weight: 18
     region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
-      size: 60
       placeholder: ''
+      suggestions_dropdown: 1
+      show_entity_id: 0
+      show_info_label: 0
+      info_label: ''
+      parent_selection: 1
     third_party_settings: {  }
   field_format:
     type: options_buttons
@@ -247,14 +260,18 @@ content:
       removed_reference: delete
     third_party_settings: {  }
   field_owner:
-    type: entity_reference_autocomplete_tags
+    type: tagify_entity_reference_autocomplete_widget
     weight: 4
     region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
-      size: 60
       placeholder: ''
+      suggestions_dropdown: 1
+      show_entity_id: 0
+      show_info_label: 0
+      info_label: ''
+      parent_selection: 1
     third_party_settings: {  }
   field_podfic_post:
     type: link_default
@@ -271,24 +288,32 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_reader:
-    type: entity_reference_autocomplete_tags
+    type: tagify_entity_reference_autocomplete_widget
     weight: 5
     region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
-      size: 60
       placeholder: ''
+      suggestions_dropdown: 1
+      show_entity_id: 0
+      show_info_label: 0
+      info_label: ''
+      parent_selection: 1
     third_party_settings: {  }
   field_relationship:
-    type: entity_reference_autocomplete_tags
+    type: tagify_entity_reference_autocomplete_widget
     weight: 19
     region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
-      size: 60
       placeholder: ''
+      suggestions_dropdown: 1
+      show_entity_id: 0
+      show_info_label: 0
+      info_label: ''
+      parent_selection: 1
     third_party_settings: {  }
   field_series:
     type: options_buttons

--- a/web/modules/custom/aa_search/src/Element/EntityAutocompleteAudiofic.php
+++ b/web/modules/custom/aa_search/src/Element/EntityAutocompleteAudiofic.php
@@ -134,12 +134,6 @@ class EntityAutocompleteAudiofic extends Textfield {
       'selection_settings_key' => $selection_settings_key,
     ])->toString();
 
-    // TODO: Do I need this?
-    $element['#attached']['drupalSettings']['aa_search']['information_message'] = [
-      'limit_tag' => t('Tags are limited to:'),
-      'no_matching_suggestions' => t('No matching suggestions found for:'),
-    ];
-
     // TODO: Should this happen here? Or should these happen in a theming hook?
     $element['#attached']['library'][] = 'aa_search/autocomplete-token-input';
     if (!isset($element['#attributes']['class'])) {

--- a/web/modules/custom/aa_search/src/Element/EntityAutocompleteAudiofic.php
+++ b/web/modules/custom/aa_search/src/Element/EntityAutocompleteAudiofic.php
@@ -3,19 +3,45 @@
 namespace Drupal\aa_search\Element;
 
 use Drupal\Component\Utility\Crypt;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element\Textfield;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\Url;
+use Drupal\Core\Render\Attribute\FormElement;
 
 /**
  * Provides a custom entity autocomplete element.
  *
- * The autocomplete uses jquery-tokeninput to display selected entities
- * as tags above the input field. Entity ID's can also be hidden.
+ * The autocomplete form element allows users to select one or multiple
+ * entities, which can come from all or specific bundles of an entity type.
+ * A jquery-tokeninput is used to display selected entities as tags above the
+ * input field. Entity ID's can also be hidden.
  *
- * @FormElement("entity_autocomplete_aa")
+ * Properties:
+ * - #target_type: (required) The ID of the target entity type.
+ * - #tags: (optional) TRUE if the element allows multiple selection. Defaults
+ *   to FALSE.
+ * - #default_value: (optional) The default entity or an array of default
+ *   entities, depending on the value of #tags.
+ * - #selection_handler: (optional) The plugin ID of the entity reference
+ *   selection handler (a plugin of type EntityReferenceSelection). The default
+ *   value is the lowest-weighted plugin that is compatible with #target-type.
+ * - #selection_settings: (optional) An array of settings for the selection
+ *   handler. Settings for the default selection handler
+ *   \Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection are:
+ *   - target_bundles: Array of bundles to allow (omit to allow all bundles).
+ *   - sort: Array with 'field' and 'direction' keys, determining how results
+ *     will be sorted. Defaults to unsorted.
+ * - #autocreate: (optional) Array of settings used to auto-create entities
+ *   that do not exist (omit to not auto-create entities). Elements:
+ *   - bundle: (required) Bundle to use for auto-created entities.
+ *   - uid: User ID to use as the author of auto-created entities. Defaults to
+ *     the current user.
+ * - #show_entity_id: (optional) TRUE if the entity id should be shown to the
+ *   user, defaults to FALSE.
  */
+#[FormElement('entity_autocomplete_aa')]
 class EntityAutocompleteAudiofic extends Textfield {
 
   /**
@@ -23,43 +49,65 @@ class EntityAutocompleteAudiofic extends Textfield {
    */
   public function getInfo(): array {
     $info = parent::getInfo();
-    $class = static::class;
 
-    $info['#maxlength'] = NULL;
     $info['#target_type'] = NULL;
     $info['#selection_handler'] = 'default';
-    $info['#selection_settings_key'] = [];
-    $info['#match_operator'] = 'CONTAINS';
-    $info['#show_entity_id'] = 0;
-    array_unshift($info['#process'], [$class, 'processEntityAutocompleteAudiofic']);
+    $info['#selection_settings'] = [];
+    $info['#tags'] = FALSE;
+    $info['#autocreate'] = NULL;
+    $info['#show_entity_id'] = FALSE;
+
+    $info['#element_validate'] = [[static::class, 'validateEntityAutocomplete']];
+    array_unshift($info['#process'], [static::class, 'processEntityAutocomplete']);
 
     return $info;
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
+    // Process the #default_value property.
+    if ($input === FALSE && isset($element['#default_value'])) {
+      if (is_array($element['#default_value']) && $element['#tags'] !== TRUE) {
+        throw new \InvalidArgumentException('The #default_value property is an array but the form element does not allow multiple values.');
+      } elseif (!empty($element['#default_value']) && !is_array($element['#default_value'])) {
+        // Convert to array for easier processing.
+        $element['#default_value'] = [$element['#default_value']];
+      }
+
+      if ($element['#default_value']) {
+        if (!(array_first($element['#default_value']) instanceof EntityInterface)) {
+          throw new \InvalidArgumentException('The #default_value property has to be an entity object or an array of entity objects.');
+        }
+
+        return static::entitiesToValue($element['#default_value']);
+      }
+    }
+
+    if ($input !== FALSE && is_array($input)) {
+      $entity_ids = array_map(fn ($item) => $item['target_id'], $input);
+      $entities = \Drupal::entityTypeManager()->getStorage($element['#target_type'])->loadMultiple($entity_ids);
+      return static::entitiesToValue($entities);
+    }
+  }
+
+  /**
    * Adds aa entity autocomplete functionality to a form element.
    */
-  public static function processEntityAutocompleteAudiofic(array &$element, FormStateInterface $form_state, array &$complete_form): array {
+  public static function processEntityAutocomplete(array &$element, FormStateInterface $form_state, array &$complete_form): array {
     // Nothing to do if there is no target entity type.
     if (empty($element['#target_type'])) {
       throw new \InvalidArgumentException('Missing required #target_type parameter.');
     }
 
-    $element['#attached']['library'][] = 'aa_search/autocomplete-token-input';
-
-    if (!isset($element['#attributes']['class'])) {
-      $element['#attributes']['class'] = [];
+    // Provide default values and sanity checks for the #autocomplete parameter.
+    if ($element['#autocreate']) {
+      if (!isset($element['#autocreate']['bundle'])) {
+        throw new \InvalidArgumentException("Missing required #autocreate['bundle'] parameter.");
+      }
+      $element['#autocreate']['uid'] = $element['#autocreate']['uid'] ?? \Drupal::currentUser()->id();
     }
-    $element['#attributes']['class'][] = 'audiofic-autocomplete-widget';
-
-    $storage = \Drupal::entityTypeManager()->getStorage($element['#target_type']);
-    $entity_ids = explode(',', $form_state->getValue($element['#name']));
-    $entities = $storage->loadMultiple($entity_ids);
-    $entity_json = static::getAudioficDefaultValue($entities);
-
-    $element['#attributes']['data-placeholder'] = $element['#placeholder'] ?? '';
-    $element['#attributes']['data-show-entity-id'] = $element['#show_entity_id'] ?? '';
-    $element['#attributes']['data-value'] = $entity_json;
 
     // Store the selection settings in the key/value store and pass a hashed key
     // in the route parameters.
@@ -71,6 +119,14 @@ class EntityAutocompleteAudiofic extends Textfield {
     if (!$key_value_storage->has($selection_settings_key)) {
       $key_value_storage->set($selection_settings_key, $selection_settings);
     }
+
+    $entity_ids = explode(',', $form_state->getValue($element['#name']));
+    $entities = \Drupal::entityTypeManager()->getStorage($element['#target_type'])->loadMultiple($entity_ids);
+    $entity_json = static::entitiesToValue($entities);
+
+    $element['#attributes']['data-placeholder'] = $element['#placeholder'] ?? '';
+    $element['#attributes']['data-show-entity-id'] = $element['#show_entity_id'] ?? '';
+    $element['#attributes']['data-value'] = $entity_json;
 
     $element['#attributes']['data-autocomplete-url'] = Url::fromRoute('aa_search.entity_autocomplete', [
       'target_type' => $element['#target_type'],
@@ -84,41 +140,120 @@ class EntityAutocompleteAudiofic extends Textfield {
       'no_matching_suggestions' => t('No matching suggestions found for:'),
     ];
 
+    // TODO: Should this happen here? Or should these happen in a theming hook?
+    $element['#attached']['library'][] = 'aa_search/autocomplete-token-input';
+    if (!isset($element['#attributes']['class'])) {
+      $element['#attributes']['class'] = [];
+    }
+    $element['#attributes']['class'][] = 'audiofic-autocomplete-widget';
+
     return $element;
   }
 
   /**
-   * {@inheritdoc}
+   * Form element validation handler for entity_autocomplete_aa elements.
    */
-  public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
-    // Process the #default_value property.
-    if ($input === FALSE && isset($element['#default_value']) && $element['#default_value']) {
-      return static::getAudioficDefaultValue($element['#default_value']);
+  public static function validateEntityAutocomplete(array &$element, FormStateInterface $form_state, array &$complete_form) {
+    // If value is empty
+    if (empty($element['#value'])) {
+      $form_state->setValueForElement($element, NULL);
+      return;
     }
 
-    if ($input !== FALSE && is_array($input)) {
-      $entity_ids = array_map(function (array $item) {
-        return $item['target_id'];
-      }, $input);
-      $entities = \Drupal::entityTypeManager()->getStorage($element['#target_type'])->loadMultiple($entity_ids);
+    $value = NULL;
 
-      return static::getAudioficDefaultValue($entities);
+    $options = $element['#selection_settings'] + [
+      'target_type' => $element['#target_type'],
+      'handler' => $element['#selection_handler'],
+    ];
+    /** @var \Drupal\Core\Entity\EntityReferenceSelection\SelectionInterface $handler */
+    $handler = \Drupal::service('plugin.manager.entity_reference_selection')->getInstance($options);
+    $autocreate = (bool) $element['#autocreate'] && $handler instanceof SelectionWithAutocreateInterface;
+
+    // GET forms might pass the validated data around on the next request, in
+    // which case it will already be in the expected format.
+    if (is_array($element['#value'])) {
+      $value = $element['#value'];
+    }
+    else {
+      foreach (json_decode($value) as $input) {
+        if (isset($input['id'])) {
+          $value[] = ['target_id' => $input['id']];
+        } elseif ($autocreate) {
+          // Auto-create item. See an example of how this is handled in
+          // \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem::presave().
+          /** @var \Drupal\Core\Entity\EntityReferenceSelection\SelectionWithAutocreateInterface $handler */
+          $value[] = [
+            'entity' => $handler->createNewEntity(
+              $element['#target_type'],
+              $element['#autocreate']['bundle'],
+              $input['name'],
+              $element['#autocreate']['uid'],
+            ),
+          ];
+        }
+      }
     }
 
-    return NULL;
+    if ($element['#validate_reference'] && !empty($value)) {
+      // Validate existing entities.
+      $ids = array_reduce($value, function ($acc, $item) {
+        return isset($item['target_id']) ? array_merge($acc, [$item['target_id']]) : $acc;
+      });
+      if ($ids) {
+        $valid_ids = $handler->validateReferenceableEntities($ids);
+        if ($invalid_ids = array_diff($ids, $valid_ids)) {
+          foreach ($invalid_ids as $invalid_id) {
+            $form_state->setError($element, t('The referenced entity (%type: %id) does not exist.', [
+              '%type' => $element['#target_type'],
+              '%id' => $invalid_id,
+            ]));
+          }
+        }
+      }
+
+      // Validate newly created entities.
+      $new_entities = array_reduce($value, function ($acc, $item) {
+        return isset($item['entity']) ? array_merge($acc, [$item['entity']]) : $acc;
+      });
+
+      if ($new_entities) {
+        if ($autocreate) {
+          $valid_new_entities = $handler->validateReferenceableNewEntities($new_entities);
+          $invalid_new_entities = array_diff_key($new_entities, $valid_new_entities);
+        } else {
+          $invalid_new_entities = $new_entities;
+        }
+
+        foreach ($invalid_new_entities as $entity) {
+          /** @var \Drupal\Core\Entity\EntityInterface $entity */
+          $form_state->setError($element, t('This entity (%type: %label) cannot be referenced.', [
+            '%type' => $element['#target_type'],
+            '%label' => $entity->label(),
+          ]));
+        }
+      }
+    }
+
+    if (!$element['#tags'] && !empty($value)) {
+      $last_value = $value[count($value) - 1];
+      $value = $last_value['target_id'] ?? $last_value;
+    }
+
+    $form_state->setValueForElement($element, $value);
   }
 
   /**
-   * Formats the default values array for this widget.
+   * Formats an array of entities to a value string.
    */
-  public static function getAudioficDefaultValue(array $entities) {
+  public static function entitiesToValue(array $entities): string {
     /** @var \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository */
     $entity_repository = \Drupal::service('entity.repository');
-    $default_value = [];
 
+    $entity_values = [];
+    /** @var \Drupal\Core\Entity\EntityInterface $entity */
     foreach ($entities as $entity) {
       // Set the entity in the correct language for display.
-      /** @var \Drupal\Core\Entity\EntityInterface $entity */
       $entity = $entity_repository->getTranslationFromContext($entity);
       $entity_id = $entity->id();
       // Use the special view label, since some entities allow the label to be
@@ -129,7 +264,7 @@ class EntityAutocompleteAudiofic extends Textfield {
         continue;
       }
 
-      $default_value[] = [
+      $entity_values[] = [
         // TODO: is it an issue that I've removed this?
         // 'value' => $entity_id,
         'id' => $entity_id,
@@ -137,7 +272,7 @@ class EntityAutocompleteAudiofic extends Textfield {
       ];
     }
 
-    return json_encode($default_value);
+    return json_encode($entity_values);
   }
 
 }

--- a/web/modules/custom/aa_search/src/Form/ComplexSearchApiForm.php
+++ b/web/modules/custom/aa_search/src/Form/ComplexSearchApiForm.php
@@ -104,7 +104,7 @@ class ComplexSearchApiForm extends FormBase {
     ];
 
     $form['fandom'] = [
-      '#type' => 'entity_autocomplete',
+      '#type' => 'entity_autocomplete_aa',
       '#title' => $this->t('Fandom'),
       '#target_type' => 'taxonomy_term',
       // Allow multiple selection.
@@ -115,7 +115,7 @@ class ComplexSearchApiForm extends FormBase {
     ];
 
     $form['relationship'] = [
-      '#type' => 'entity_autocomplete',
+      '#type' => 'entity_autocomplete_aa',
       '#title' => $this->t('Relationship'),
       '#target_type' => 'taxonomy_term',
       // Allow multiple selection.


### PR DESCRIPTION
closes: #21 

Fully implemented the Audiofic entity autocomplete element (`web/modules/custom/aa_search/src/Element/EntityAutocompleteAudiofic.php`) And used it in the ComplexSearchApiForm to fix the tag filtering bug present.

The autocomplete element is also now primed to autocreate new tags - if asked to do so. This is not yet tested, so if we want to start doing that somewhere it will require testing!

I have also re-enabled the tagify widget for the work form.