### PR TITLE
Ensure migration handles canonicity correctly

### DIFF
--- a/web/modules/custom/audiofic_archive_migrations/migrations/aa_d7_taxonomy_term_fandom.yml
+++ b/web/modules/custom/audiofic_archive_migrations/migrations/aa_d7_taxonomy_term_fandom.yml
@@ -28,9 +28,8 @@ process:
   changed: timestamp
   langcode: language
   field_canonicity:
-    plugin: default_value
-    default_value:
-      - value: 'canon'
+    plugin: aa_fandom_canonicity
+    source: name
 destination:
   plugin: entity:taxonomy_term
 migration_dependencies:

--- a/web/modules/custom/audiofic_archive_migrations/src/Plugin/migrate/process/FandomCanonicityProcessPlugin.php
+++ b/web/modules/custom/audiofic_archive_migrations/src/Plugin/migrate/process/FandomCanonicityProcessPlugin.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\audiofic_archive_migrations\Plugin\migrate\process;
+
+use Drupal\migrate\Attribute\MigrateProcess;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * FandomCanonicityProcessPlugin correctly sets the canonicity of fandoms.
+ *
+ * All fandoms default to being "canon", but any which are in the root fandom
+ * list are made "canonical_root_fandom".
+ */
+#[MigrateProcess(
+  id: "aa_fandom_canonicity",
+  handle_multiples: TRUE,
+)]
+class FandomCanonicityProcessPlugin extends ProcessPluginBase {
+
+  /**
+   * The list of root fandoms.
+   *
+   * @var array
+   */
+  public const array ROOT_FANDOMS = [
+    'anime/manga/manhwa/donghua fandoms',
+    'audio series',
+    'board, card, & tabletop games',
+    'comics fandoms',
+    'gaming fandoms',
+    'literature fandoms',
+    'meta fandoms',
+    'movie fandoms - animation',
+    'movie fandoms - live action',
+    'other media',
+    'rpf fandoms',
+    'short film, ads, and videos',
+    'television fandoms - animation',
+    'television fandoms - live action',
+    'theatre/stage fandoms',
+    'web series',
+    'no fandom specified',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform(
+    $value,
+    MigrateExecutableInterface $migrate_executable,
+    Row $row,
+    $destination_property,
+  ) {
+    $name = $row->getSourceProperty($this->configuration['source']);
+    if (in_array($name, $this::ROOT_FANDOMS)) {
+      return [['value' => 'canonical_root_fandom']];
+    }
+
+    return [['value' => 'canon']];
+  }
+
+}

--- a/web/modules/custom/audiofic_archive_wrangling/src/Controller/TagWranglingController.php
+++ b/web/modules/custom/audiofic_archive_wrangling/src/Controller/TagWranglingController.php
@@ -242,17 +242,33 @@ class TagWranglingController extends ControllerBase {
    *   Array of taxonomy terms to load data on.
    */
   private function loadFandomList(array $taxonomy_terms): array {
+    /** @var \Drupal\taxonomy\TermStorage $term_storage */
+    $term_storage = $this->entityTypeManager->getStorage('taxonomy_term');
+
     $fandoms = [];
+    $grandchildren = [];
+    /** @var \Drupal\taxonomy\TermInterface $fandom */
     foreach ($taxonomy_terms as $tid => $fandom) {
-      $children = $this->entityTypeManager->getStorage('taxonomy_term')->getQuery()
+      if (in_array($tid, $grandchildren)) {
+        continue;
+      }
+      $children = $term_storage->getQuery()
         ->accessCheck(TRUE)
         ->condition('field_canonicity', 'canon')
         ->condition('parent.entity:taxonomy_term.tid', $tid)
         ->execute();
+      $grandchildren = array_merge($grandchildren, $children);
+      $parents = $term_storage->loadParents($tid);
+      $parents_str = empty($parents) ? '' : 'Parent(s): ' . implode(', ', array_map(fn ($t) => $t->getName(), $parents));
       $fandoms[$tid] = [
         'name' => $fandom->getName(),
         'has_children' => !empty($children),
+        'parents' => $parents_str,
       ];
+    }
+    // Remove all terms which will appear lower in the tree later on.
+    foreach ($grandchildren as $tid) {
+      unset($fandoms[$tid]);
     }
     uasort($fandoms, function ($a, $b) {
       return strcmp($a['name'], $b['name']);

--- a/web/modules/custom/audiofic_archive_wrangling/templates/browse-canon-fandoms.html.twig
+++ b/web/modules/custom/audiofic_archive_wrangling/templates/browse-canon-fandoms.html.twig
@@ -2,7 +2,11 @@
 
 <ul class="{{ top_level ? 'fandom-tree' : '' }}">
   {% for tid, fandom in fandoms %}
-  <li data-tid="{{ tid }}" class="{{ fandom.has_children ? '' : 'fandom-tree-leaf' }}">
+  <li
+    data-tid="{{ tid }}"
+    class="{{ fandom.has_children ? '' : 'fandom-tree-leaf' }}"
+    title="{{ fandom.parents }}"
+  >
     {% if fandom.has_children %}
     <details data-tid="{{ tid }}" data-children-loaded="false">
       <summary><span>{{ fandom.name }}</span><a href="{{ edit_url }}{{ tid }}">edit</a></summary>


### PR DESCRIPTION
Add a migration processor to handle root fandoms correctly & extend the fandom browsing page

closes: #72