### PR TITLE
68 ensure non canonical taxonomy term pages are handled

### DIFF
--- a/config/block.block.bootstrap_barrio_subtheme_exposedformsearchsearch_taxonomy.yml
+++ b/config/block.block.bootstrap_barrio_subtheme_exposedformsearchsearch_taxonomy.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - views.view.search
   module:
+    - aa_search
     - system
     - taxonomy
     - views
@@ -45,3 +46,9 @@ visibility:
       reader: reader
       relationship: relationship
       warning: warning
+  taxonomy_canonical_condition:
+    id: taxonomy_canonical_condition
+    disable_not_canonical: 1
+    negate: 0
+    context_mapping:
+      taxonomy_term: '@taxonomy_term.taxonomy_term_route_context:taxonomy_term'

--- a/config/core.entity_view_display.taxonomy_term.fandom.default.yml
+++ b/config/core.entity_view_display.taxonomy_term.fandom.default.yml
@@ -31,7 +31,7 @@ content:
     region: content
   field_canonicity:
     type: list_default
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 1

--- a/config/views.view.unwrangled_tag_works.yml
+++ b/config/views.view.unwrangled_tag_works.yml
@@ -560,7 +560,7 @@ display:
         - 'config:field.storage.node.field_text_post'
   unwrangled_fandom_tag_works:
     id: unwrangled_fandom_tag_works
-    display_title: Block
+    display_title: 'Fandom Block (Admin facing)'
     display_plugin: block
     position: 1
     display_options:
@@ -618,6 +618,7 @@ display:
           admin_label: 'field_fandom2: Taxonomy term'
           plugin_id: standard
           required: true
+      display_description: ''
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -630,9 +631,135 @@ display:
       tags:
         - 'config:field.storage.node.field_podfic_post'
         - 'config:field.storage.node.field_text_post'
+  unwrangled_fandom_tag_works_content:
+    id: unwrangled_fandom_tag_works_content
+    display_title: 'Fandom Block (User facing)'
+    display_plugin: block
+    position: 1
+    display_options:
+      title: 'Works which have used this as a tag:'
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 20
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      arguments:
+        tid:
+          id: tid
+          table: taxonomy_term_field_data
+          field: tid
+          relationship: field_fandom2
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: tid
+          plugin_id: taxonomy
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: false
+            limit: false
+            vids: {  }
+            anyall: ','
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      defaults:
+        title: false
+        pager: false
+        style: false
+        row: false
+        relationships: false
+        arguments: false
+        header: false
+      relationships:
+        field_fandom2:
+          id: field_fandom2
+          table: node__field_fandom2
+          field: field_fandom2
+          relationship: none
+          group_type: group
+          admin_label: 'field_fandom2: Taxonomy term'
+          plugin_id: standard
+          required: true
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: '<h3>Works which have used this as a tag:</h3>'
+            format: basic_html
+          tokenize: false
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.node.field_podfic_post'
+        - 'config:field.storage.node.field_text_post'
   unwrangled_relationship_tag_works:
     id: unwrangled_relationship_tag_works
-    display_title: Block
+    display_title: 'Relationship Block (Admin facing)'
     display_plugin: block
     position: 1
     display_options:
@@ -691,6 +818,107 @@ display:
           admin_label: 'field_relationship: Taxonomy term'
           plugin_id: standard
           required: true
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.node.field_podfic_post'
+        - 'config:field.storage.node.field_text_post'
+  unwrangled_relationship_tag_works_content:
+    id: unwrangled_relationship_tag_works_content
+    display_title: 'Relationship Block (User facing)'
+    display_plugin: block
+    position: 1
+    display_options:
+      arguments:
+        tid:
+          id: tid
+          table: taxonomy_term_field_data
+          field: tid
+          relationship: field_relationship
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: tid
+          plugin_id: taxonomy
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: false
+            limit: false
+            vids: {  }
+            anyall: ','
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      defaults:
+        style: false
+        row: false
+        relationships: false
+        arguments: false
+        header: false
+      relationships:
+        field_relationship:
+          id: field_relationship
+          table: node__field_relationship
+          field: field_relationship
+          relationship: none
+          group_type: group
+          admin_label: 'field_relationship: Taxonomy term'
+          plugin_id: standard
+          required: true
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: '<h3>Works which have used this as a tag:</h3>'
+            format: basic_html
+          tokenize: false
       display_extenders: {  }
     cache_metadata:
       max-age: -1

--- a/web/modules/custom/aa_search/src/Hook/AASearchThemeHooks.php
+++ b/web/modules/custom/aa_search/src/Hook/AASearchThemeHooks.php
@@ -4,6 +4,7 @@ namespace Drupal\aa_search\Hook;
 
 use Drupal\aa_utils\Service\AudioficTagUtils;
 use Drupal\aa_utils\Service\AudioficUtils;
+use Drupal\block\Entity\Block;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Hook\Attribute\Hook;
@@ -137,17 +138,24 @@ class AASearchThemeHooks {
     }
 
     if (
-      $route_name !== 'entity.taxonomy_term.canonical' or
-      !\array_key_exists('title', $variables) or
-      !\is_array($variables['title']) or
-      !\array_key_exists('#markup', $variables['title'])
+      $route_name == 'entity.taxonomy_term.canonical' &&
+      isset($variables['title']) &&
+      isset($variables['title']['#markup'])
     ) {
-      return;
-    }
+      $term = $this->route_match->getParameter('taxonomy_term');
+      if ($term->bundle() === 'series') {
+        $variables['title'] = NULL;
+      }
 
-    $term = $this->route_match->getParameter('taxonomy_term');
-    if ($term->bundle() === 'series') {
-      $variables['title'] = NULL;
+      if (!$this->tag_utils->isTagCanonicityAware($term)) {
+        return;
+      }
+      $canonicity = $term->get('field_canonicity')->value;
+      if ($canonicity == 'canon') {
+        return;
+      }
+
+      $variables['title']['#markup'] = $term->getName();
     }
   }
 
@@ -223,6 +231,12 @@ class AASearchThemeHooks {
 
         $variables['rss_feed'] = '/taxonomy/term/' . $tid . '/rss.xml?' . $url_data['url_query'];
         $variables['taxonomy_term'] = $term;
+
+        if ($this->tag_utils->isTagCanonicityAware($term)) {
+          $variables['canon'] = $term->get('field_canonicity')->value == 'canon';
+        } else {
+          $variables['canon'] = TRUE;
+        }
 
         /** @var \Drupal\taxonomy\TermStorageInterface $taxonomy_term_storage */
         $taxonomy_term_storage = $this->entity_type_manager->getStorage('taxonomy_term');

--- a/web/modules/custom/aa_search/src/Plugin/Condition/TaxonomyCanonicalCondition.php
+++ b/web/modules/custom/aa_search/src/Plugin/Condition/TaxonomyCanonicalCondition.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Drupal\aa_search\Plugin\Condition;
+
+use Drupal\aa_utils\Service\AudioficTagUtils;
+use Drupal\Core\Condition\Attribute\Condition;
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\Context\EntityContextDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides the Taxonomy is Canonical condition.
+ *
+ * Used to conditionally render blocks (or not) based on whether
+ * the page they will be rendered on contains a canonical taxonomy
+ * term or not.
+ */
+#[Condition(
+  id: 'taxonomy_canonical_condition',
+  label: new TranslatableMarkup('Taxonomy term canonical condition'),
+  context_definitions: [
+    'taxonomy_term' => new EntityContextDefinition(
+      data_type: 'entity:taxonomy_term',
+      label: new TranslatableMarkup('Taxonomy Term'),
+      required: FALSE,
+    ),
+  ]
+)]
+class TaxonomyCanonicalCondition extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The Tag Utils Service.
+   *
+   * @var \Drupal\aa_utils\Service\AudioficTagUtils
+   */
+  protected $tagUtils;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('aa_utils.tag_utils'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, AudioficTagUtils $tag_utils) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->tagUtils = $tag_utils;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form['disable_not_canonical'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Hide when taxonomy term is not canonical'),
+      '#default_value' => $this->configuration['disable_not_canonical'],
+      '#description' => $this->t('Hide this block when on a non-canonical taxonomy term page'),
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['disable_not_canonical'] = $form_state->getValue('disable_not_canonical');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return ['disable_not_canonical' => 0] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * TODO: I'm not taking into account the negation field right now.
+   * If I ever end up wanting to use this more generally, probably will want
+   * to do that!
+   */
+  public function evaluate() {
+    $term = $this->getContextValue('taxonomy_term');
+    if (!$term) {
+      return TRUE;
+    }
+    if (!$this->configuration['disable_not_canonical']) {
+      return TRUE;
+    }
+    if (!$this->tagUtils->isTagCanonicityAware($term)) {
+      return TRUE;
+    }
+
+    // Hide if not canonical.
+    return $term->get('field_canonicity')->value == 'canon';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    $status = $this->configuration['disable_not_canonical'] ? $this->t('enabled') : $this->t('disabled');
+    return $this->t(
+      'Hide when taxonomy term is not canonical: @status.',
+      ['@status' => $status],
+    );
+  }
+
+}

--- a/web/modules/custom/audiofic_archive_wrangling/src/Form/WrangleNonCanonicalTagForm.php
+++ b/web/modules/custom/audiofic_archive_wrangling/src/Form/WrangleNonCanonicalTagForm.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityFieldManager;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\redirect\Entity\Redirect;
 use Drupal\taxonomy\TermInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
@@ -168,7 +169,13 @@ class WrangleNonCanonicalTagForm extends FormBase {
       }
 
       $this->term->set('field_canon_sibling', $canon_sibling_term);
+      $this->createRedirect($this->term, $canon_sibling_term);
     } else {
+      $previous_canon_sibling = $this->term->get('field_canon_sibling')->referencedEntities();
+      if (!empty($previous_canon_sibling)) {
+        $this->removeRedirect($this->term, $previous_canon_sibling[0]);
+      }
+
       $this->term->set('field_canon_sibling', NULL);
     }
 
@@ -182,6 +189,61 @@ class WrangleNonCanonicalTagForm extends FormBase {
    */
   public function getFormId(): string {
     return "wrangle_non_canonical_tag_form";
+  }
+
+  /**
+   * Creates a redirect between two terms.
+   */
+  private function createRedirect(TermInterface $source, TermInterface $destination) {
+    $existing_redirect_ids = $this->entityTypeManager->getStorage('redirect')->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('redirect_source.path', 'taxonomy/term/' . $source->id())
+      ->execute();
+
+    $redirect_already_exists = FALSE;
+    foreach (Redirect::loadMultiple($existing_redirect_ids) as $existing_redirect) {
+      if ($existing_redirect->getRedirect()['uri'] == 'internal:/taxonomy/term/' . $destination->id()) {
+        $redirect_already_exists = TRUE;
+        continue;
+      }
+
+      $existing_redirect->delete();
+    }
+
+    if ($redirect_already_exists) {
+      return;
+    }
+
+    $redirect = Redirect::create([
+      'redirect_source' => [
+        'path' => 'taxonomy/term/' . $source->id(),
+        'query' => [],
+      ],
+      'redirect_redirect' => [
+        'uri' => 'internal:/taxonomy/term/' . $destination->id(),
+        'options' => [],
+      ],
+      'status_code' => '301',
+    ]);
+    $redirect->save();
+  }
+
+  /**
+   * Removes any redirects that exist between two terms.
+   */
+  private function removeRedirect(TermInterface $source, TermInterface $destination) {
+    $existing_redirect_ids = $this->entityTypeManager->getStorage('redirect')->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('redirect_source.path', 'taxonomy/term/' . $source->id())
+      ->execute();
+
+    foreach (Redirect::loadMultiple($existing_redirect_ids) as $existing_redirect) {
+      if ($existing_redirect->getRedirect()['uri'] != 'internal:/taxonomy/term/' . $destination->id()) {
+        continue;
+      }
+
+      $existing_redirect->delete();
+    }
   }
 
 }

--- a/web/themes/custom/sandbox/templates/field/field--taxonomy_term--field_canonicity.html.twig
+++ b/web/themes/custom/sandbox/templates/field/field--taxonomy_term--field_canonicity.html.twig
@@ -1,0 +1,42 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{% for item in items %}
+    {{ item.content }}
+{% endfor %}

--- a/web/themes/custom/sandbox/templates/views/views-view--search.html.twig
+++ b/web/themes/custom/sandbox/templates/views/views-view--search.html.twig
@@ -92,6 +92,14 @@
         </div>
       </div>
   </div>
+{% elseif view.id == "search" and view.current_display == "search_taxonomy" and taxonomy_term != NULL and not canon %}
+  <p>This tag is {{ drupal_field('field_canonicity', 'taxonomy_term', taxonomy_term.id) }} and cannot be toggled on for sorting.</p>
+  <p>This is a {{ taxonomy_term.bundle }} tag.</p>
+  {% if taxonomy_term.bundle == "fandom" %}
+  {{ drupal_view("unwrangled_tag_works", "unwrangled_fandom_tag_works_content") }}
+  {% elseif taxonomy_term.bundle == "relationship" %}
+  {{ drupal_view("unwrangled_tag_works", "unwrangled_relationship_tag_works_content") }}
+  {% endif %}
 {% else %}
   {%
     set classes = [


### PR DESCRIPTION
If a tag is non-canon & has a sibling, it redirects to the canonical search page.
If a tag is non-canon & does not have a sibling, a page which explains that it is not canonical & lists all works which directly tag it is shown.

closes: #68