### PR TITLE
18 make sure that deleting a chapter deletes the media it is linked to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ components/
 **/node_modules
 db_backups/
 private_files/
+.vscode/

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,8 @@
         "drupal/file_download": "^2.0",
         "drupal/gin": "^5.0",
         "drupal/gin_toolbar": "^3.0",
+        "drupal/image_effects": "^5.0",
+        "drupal/imagemagick": "^5.0",
         "drupal/inline_entity_form": "^3.0@RC",
         "drupal/metatag": "^2.1",
         "drupal/pathauto": "^1.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0da73ad6dd0aceaa69fd7f288e87eba",
+    "content-hash": "d41e22bd6fd98e1615afcc079432f88e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1288,6 +1288,51 @@
             "time": "2025-10-16T20:13:18+00:00"
         },
         {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11 || ^12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.2"
+            },
+            "time": "2026-01-20T14:10:26+00:00"
+        },
+        {
             "name": "drupal/admin_toolbar",
             "version": "3.6.3",
             "source": {
@@ -2568,6 +2613,124 @@
             }
         },
         {
+            "name": "drupal/file_mdm",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/file_mdm.git",
+                "reference": "3.2.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/file_mdm-3.2.0.zip",
+                "reference": "3.2.0",
+                "shasum": "0cb085a19b6ba9657f1e154ff3139b253945d054"
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.1",
+                "drupal/core": "^11.2",
+                "fileeye/pel": "^0.12"
+            },
+            "require-dev": {
+                "drupal/vendor_stream_wrapper": "^2.0.5",
+                "fileeye/linuxlibertine-fonts": "^5.3"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.2.0",
+                    "datestamp": "1752175711",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                }
+            ],
+            "description": "Provides a service to manage file metadata.",
+            "homepage": "https://www.drupal.org/project/file_mdm",
+            "support": {
+                "source": "https://git.drupalcode.org/project/file_mdm"
+            }
+        },
+        {
+            "name": "drupal/file_mdm_exif",
+            "version": "3.2.0",
+            "require": {
+                "drupal/core": "^11.2",
+                "drupal/file_mdm": "*"
+            },
+            "type": "metapackage",
+            "extra": {
+                "drupal": {
+                    "version": "3.2.0",
+                    "datestamp": "1752175711",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                }
+            ],
+            "description": "Provides a file metadata plugin for EXIF image information.",
+            "homepage": "https://www.drupal.org/project/file_mdm",
+            "support": {
+                "source": "https://git.drupalcode.org/project/file_mdm"
+            }
+        },
+        {
+            "name": "drupal/file_mdm_font",
+            "version": "3.2.0",
+            "require": {
+                "drupal/core": "^11.2",
+                "drupal/file_mdm": "*"
+            },
+            "type": "metapackage",
+            "extra": {
+                "drupal": {
+                    "version": "3.2.0",
+                    "datestamp": "1752175711",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                }
+            ],
+            "description": "Provides a file metadata plugin for TTF/OTF/WOFF font information.",
+            "homepage": "https://www.drupal.org/project/file_mdm",
+            "support": {
+                "source": "https://git.drupalcode.org/project/file_mdm"
+            }
+        },
+        {
             "name": "drupal/gin",
             "version": "5.0.12",
             "source": {
@@ -2695,6 +2858,162 @@
                     "url": "https://paypal.me/saschaeggi"
                 }
             ]
+        },
+        {
+            "name": "drupal/image_effects",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/image_effects.git",
+                "reference": "5.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/image_effects-5.0.0.zip",
+                "reference": "5.0.0",
+                "shasum": "6f4c50bdb35127053e3625d855428627d4bf0415"
+            },
+            "require": {
+                "drupal/core": "^11.3",
+                "drupal/file_mdm": "^3.2",
+                "drupal/file_mdm_exif": "*",
+                "drupal/file_mdm_font": "*"
+            },
+            "conflict": {
+                "drupal/imagemagick": "<5"
+            },
+            "require-dev": {
+                "drupal/imagemagick": "^5",
+                "drupal/textimage": "^5",
+                "drupal/token": "*",
+                "drupal/vendor_stream_wrapper": "^2.0.5",
+                "drush/drush": ">=13",
+                "fileeye/linuxlibertine-fonts": "^5.3"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "5.0.0",
+                    "datestamp": "1769890352",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": ">=9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                }
+            ],
+            "description": "Provides effects and operations for the Image API.",
+            "homepage": "https://www.drupal.org/project/image_effects",
+            "support": {
+                "source": "https://git.drupalcode.org/project/image_effects"
+            }
+        },
+        {
+            "name": "drupal/imagemagick",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/imagemagick.git",
+                "reference": "5.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/imagemagick-5.0.1.zip",
+                "reference": "5.0.1",
+                "shasum": "3a9e70d80064b3be3f2d0b4b4a4d1beb92d6ead2"
+            },
+            "require": {
+                "drupal/core": "^11.3",
+                "drupal/file_mdm": "^3.2",
+                "drupal/sophron": "^3"
+            },
+            "require-dev": {
+                "drupal/image_effects": "^5"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "5.0.1",
+                    "datestamp": "1769759255",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Charlton",
+                    "homepage": "https://www.drupal.org/user/17089"
+                },
+                {
+                    "name": "chx",
+                    "homepage": "https://www.drupal.org/user/9446"
+                },
+                {
+                    "name": "claudiu.cristea",
+                    "homepage": "https://www.drupal.org/user/56348"
+                },
+                {
+                    "name": "dman",
+                    "homepage": "https://www.drupal.org/user/33240"
+                },
+                {
+                    "name": "dopry",
+                    "homepage": "https://www.drupal.org/user/22202"
+                },
+                {
+                    "name": "drewish",
+                    "homepage": "https://www.drupal.org/user/34869"
+                },
+                {
+                    "name": "gdl",
+                    "homepage": "https://www.drupal.org/user/507326"
+                },
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                },
+                {
+                    "name": "quicksketch",
+                    "homepage": "https://www.drupal.org/user/35821"
+                },
+                {
+                    "name": "sun",
+                    "homepage": "https://www.drupal.org/user/54136"
+                },
+                {
+                    "name": "walkah",
+                    "homepage": "https://www.drupal.org/user/1531"
+                }
+            ],
+            "description": "Provides an image toolkit to integrate ImageMagick with the Image API.",
+            "homepage": "https://www.drupal.org/project/imagemagick",
+            "support": {
+                "source": "https://git.drupalcode.org/project/imagemagick"
+            }
         },
         {
             "name": "drupal/inline_entity_form",
@@ -3413,6 +3732,56 @@
             "homepage": "https://www.drupal.org/project/shortcutperrole",
             "support": {
                 "source": "https://git.drupalcode.org/project/shortcutperrole"
+            }
+        },
+        {
+            "name": "drupal/sophron",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/sophron.git",
+                "reference": "3.1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/sophron-3.1.1.zip",
+                "reference": "3.1.1",
+                "shasum": "6fd86916ab6a620372c474a8a1ba15edeb989f4b"
+            },
+            "require": {
+                "drupal/core": "^11.2 | ^12",
+                "fileeye/mimemap": "^2.2.5"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.1.1",
+                    "datestamp": "1774250660",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Drupal\\sophron\\": "src/"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                }
+            ],
+            "description": "Provides an extensive MIME types management API",
+            "homepage": "https://www.drupal.org/project/sophron",
+            "support": {
+                "source": "https://git.drupalcode.org/project/sophron"
             }
         },
         {
@@ -4467,6 +4836,126 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "fileeye/mimemap",
+            "version": "2.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FileEye/MimeMap.git",
+                "reference": "d85461d6663501d29d1838d1ad65222a1ce44d7b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FileEye/MimeMap/zipball/d85461d6663501d29d1838d1ad65222a1ce44d7b",
+                "reference": "d85461d6663501d29d1838d1ad65222a1ce44d7b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "composer-runtime-api": "^2.0.0",
+                "sebastian/comparator": ">=5",
+                "sebastian/diff": ">=5",
+                "symfony/console": ">=6.4",
+                "symfony/filesystem": ">=6.4",
+                "symfony/var-dumper": ">=6.4",
+                "symfony/yaml": ">=6.4"
+            },
+            "bin": [
+                "bin/fileeye-mimemap"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "FileEye\\MimeMap\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "description": "A PHP library to handle MIME Content-Type fields and their related file extensions.",
+            "homepage": "https://github.com/FileEye/MimeMap",
+            "keywords": [
+                "mime",
+                "mime-database",
+                "mime-parser",
+                "mime-type"
+            ],
+            "support": {
+                "issues": "https://github.com/FileEye/MimeMap/issues",
+                "source": "https://github.com/FileEye/MimeMap/tree/2.2.5"
+            },
+            "time": "2026-03-22T21:57:45+00:00"
+        },
+        {
+            "name": "fileeye/pel",
+            "version": "0.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FileEye/pel.git",
+                "reference": "96cce8aef576c8fe3154282d9d37f3cace7455e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FileEye/pel/zipball/96cce8aef576c8fe3154282d9d37f3cace7455e9",
+                "reference": "96cce8aef576c8fe3154282d9d37f3cace7455e9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-exif": "*",
+                "ext-gd": "*",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-phpunit": "^2",
+                "phpunit/phpunit": "^10 || ^11 || ^12 || ^13",
+                "squizlabs/php_codesniffer": ">=3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "lsolesen\\pel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Olesen",
+                    "email": "lars@intraface.dk",
+                    "homepage": "http://intraface.dk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Martin Geisler",
+                    "email": "martin@geisler.net",
+                    "homepage": "http://geisler.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Exif Library. A library for reading and writing Exif headers in JPEG and TIFF images using PHP.",
+            "homepage": "https://github.com/FileEye/pel",
+            "keywords": [
+                "exif",
+                "image"
+            ],
+            "support": {
+                "issues": "https://github.com/FileEye/pel/issues",
+                "source": "https://github.com/FileEye/pel/tree/0.12.1"
+            },
+            "time": "2026-03-19T18:27:55+00:00"
         },
         {
             "name": "grasmash/expander",

--- a/config/core.entity_form_display.media.mp3_file.default.yml
+++ b/config/core.entity_form_display.media.mp3_file.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.media.mp3_file.field_duration_seconds
     - field.field.media.mp3_file.field_filename
     - field.field.media.mp3_file.field_media_audio_file
+    - field.field.media.mp3_file.field_owner
     - field.field.media.mp3_file.field_use_for_duration
     - media.type.mp3_file
   module:
@@ -33,7 +34,7 @@ content:
     third_party_settings: {  }
   field_use_for_duration:
     type: boolean_checkbox
-    weight: 26
+    weight: 4
     region: content
     settings:
       display_label: true
@@ -57,6 +58,7 @@ hidden:
   created: true
   field_duration_seconds: true
   field_filename: true
+  field_owner: true
   path: true
   status: true
   uid: true

--- a/config/core.entity_form_display.media.mp3_file.media_library.yml
+++ b/config/core.entity_form_display.media.mp3_file.media_library.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.media.mp3_file.field_duration_seconds
     - field.field.media.mp3_file.field_filename
     - field.field.media.mp3_file.field_media_audio_file
+    - field.field.media.mp3_file.field_owner
     - field.field.media.mp3_file.field_use_for_duration
     - media.type.mp3_file
 id: media.mp3_file.media_library
@@ -36,6 +37,7 @@ hidden:
   field_duration_seconds: true
   field_filename: true
   field_media_audio_file: true
+  field_owner: true
   field_use_for_duration: true
   path: true
   status: true

--- a/config/core.entity_form_display.media.other_file.default.yml
+++ b/config/core.entity_form_display.media.other_file.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.media.other_file.field_file_label
     - field.field.media.other_file.field_filename
     - field.field.media.other_file.field_media_file
+    - field.field.media.other_file.field_owner
     - media.type.other_file
   module:
     - file
@@ -47,6 +48,7 @@ content:
 hidden:
   created: true
   field_filename: true
+  field_owner: true
   path: true
   status: true
   uid: true

--- a/config/core.entity_form_display.media.other_file.media_library.yml
+++ b/config/core.entity_form_display.media.other_file.media_library.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.media.other_file.field_file_label
     - field.field.media.other_file.field_filename
     - field.field.media.other_file.field_media_file
+    - field.field.media.other_file.field_owner
     - media.type.other_file
 id: media.other_file.media_library
 targetEntityType: media
@@ -33,6 +34,7 @@ hidden:
   field_file_label: true
   field_filename: true
   field_media_file: true
+  field_owner: true
   path: true
   status: true
   uid: true

--- a/config/core.entity_form_display.node.legacy_work.default.yml
+++ b/config/core.entity_form_display.node.legacy_work.default.yml
@@ -19,7 +19,7 @@ dependencies:
     - field.field.node.legacy_work.field_reader
     - field.field.node.legacy_work.field_relationship
     - field.field.node.legacy_work.field_warning
-    - image.style.thumbnail
+    - image.style.large
     - node.type.legacy_work
   module:
     - duration_field
@@ -118,7 +118,7 @@ content:
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: large
     third_party_settings: {  }
   field_duration:
     type: duration_widget

--- a/config/core.entity_form_display.node.playlist.default.yml
+++ b/config/core.entity_form_display.node.playlist.default.yml
@@ -20,7 +20,7 @@ dependencies:
     - field.field.node.playlist.field_summary
     - field.field.node.playlist.field_warning
     - field.field.node.playlist.field_works_series
-    - image.style.thumbnail
+    - image.style.large
     - node.type.playlist
   module:
     - image
@@ -36,7 +36,7 @@ content:
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: large
     third_party_settings: {  }
   field_summary:
     type: text_textarea

--- a/config/core.entity_form_display.node.work.default.yml
+++ b/config/core.entity_form_display.node.work.default.yml
@@ -31,7 +31,7 @@ dependencies:
     - field.field.node.work.field_summary
     - field.field.node.work.field_text_post
     - field.field.node.work.field_warning
-    - image.style.small_square
+    - image.style.large
     - node.type.work
   module:
     - field_group
@@ -181,7 +181,7 @@ content:
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: small_square
+      preview_image_style: large
     third_party_settings: {  }
   field_cover_artist:
     type: tagify_entity_reference_autocomplete_widget

--- a/config/core.entity_view_display.media.mp3_file.default.yml
+++ b/config/core.entity_view_display.media.mp3_file.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.media.mp3_file.field_duration_seconds
     - field.field.media.mp3_file.field_filename
     - field.field.media.mp3_file.field_media_audio_file
+    - field.field.media.mp3_file.field_owner
     - field.field.media.mp3_file.field_use_for_duration
     - media.type.mp3_file
   module:
@@ -51,6 +52,14 @@ content:
       multiple_file_display_type: tags
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_owner:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 6
     region: content
   field_use_for_duration:
     type: boolean

--- a/config/core.entity_view_display.media.mp3_file.file_only.yml
+++ b/config/core.entity_view_display.media.mp3_file.file_only.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.media.mp3_file.field_duration_seconds
     - field.field.media.mp3_file.field_filename
     - field.field.media.mp3_file.field_media_audio_file
+    - field.field.media.mp3_file.field_owner
     - field.field.media.mp3_file.field_use_for_duration
     - media.type.mp3_file
   module:
@@ -39,6 +40,7 @@ hidden:
   created: true
   field_duration_seconds: true
   field_filename: true
+  field_owner: true
   field_use_for_duration: true
   langcode: true
   name: true

--- a/config/core.entity_view_display.media.mp3_file.media_library.yml
+++ b/config/core.entity_view_display.media.mp3_file.media_library.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.media.mp3_file.field_duration_seconds
     - field.field.media.mp3_file.field_filename
     - field.field.media.mp3_file.field_media_audio_file
+    - field.field.media.mp3_file.field_owner
     - field.field.media.mp3_file.field_use_for_duration
     - image.style.medium
     - media.type.mp3_file
@@ -35,6 +36,7 @@ hidden:
   field_duration_seconds: true
   field_filename: true
   field_media_audio_file: true
+  field_owner: true
   field_use_for_duration: true
   langcode: true
   name: true

--- a/config/core.entity_view_display.media.mp3_file.stream.yml
+++ b/config/core.entity_view_display.media.mp3_file.stream.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.media.mp3_file.field_duration_seconds
     - field.field.media.mp3_file.field_filename
     - field.field.media.mp3_file.field_media_audio_file
+    - field.field.media.mp3_file.field_owner
     - field.field.media.mp3_file.field_use_for_duration
     - media.type.mp3_file
   module:
@@ -40,6 +41,7 @@ hidden:
   created: true
   field_duration_seconds: true
   field_filename: true
+  field_owner: true
   field_use_for_duration: true
   langcode: true
   name: true

--- a/config/core.entity_view_display.media.other_file.default.yml
+++ b/config/core.entity_view_display.media.other_file.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.media.other_file.field_file_label
     - field.field.media.other_file.field_filename
     - field.field.media.other_file.field_media_file
+    - field.field.media.other_file.field_owner
     - media.type.other_file
   module:
     - file
@@ -37,6 +38,14 @@ content:
       use_description_as_link_text: true
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_owner:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 6
     region: content
 hidden:
   created: true

--- a/config/core.entity_view_display.media.other_file.media_library.yml
+++ b/config/core.entity_view_display.media.other_file.media_library.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.media.other_file.field_file_label
     - field.field.media.other_file.field_filename
     - field.field.media.other_file.field_media_file
+    - field.field.media.other_file.field_owner
     - image.style.medium
     - media.type.other_file
   module:
@@ -32,6 +33,7 @@ hidden:
   field_file_label: true
   field_filename: true
   field_media_file: true
+  field_owner: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/config/core.entity_view_display.node.legacy_work.default.yml
+++ b/config/core.entity_view_display.node.legacy_work.default.yml
@@ -19,11 +19,11 @@ dependencies:
     - field.field.node.legacy_work.field_reader
     - field.field.node.legacy_work.field_relationship
     - field.field.node.legacy_work.field_warning
-    - image.style.medium_square
     - node.type.legacy_work
+    - responsive_image.styles.details_cover
   module:
     - duration_field
-    - image
+    - responsive_image
     - text
     - user
 id: node.legacy_work.default
@@ -65,11 +65,11 @@ content:
     weight: 3
     region: content
   field_cover:
-    type: image
+    type: responsive_image
     label: hidden
     settings:
+      responsive_image_style: details_cover
       image_link: ''
-      image_style: medium_square
       image_loading:
         attribute: lazy
     third_party_settings: {  }

--- a/config/core.entity_view_display.node.playlist.default.yml
+++ b/config/core.entity_view_display.node.playlist.default.yml
@@ -20,11 +20,11 @@ dependencies:
     - field.field.node.playlist.field_summary
     - field.field.node.playlist.field_warning
     - field.field.node.playlist.field_works_series
-    - image.style.medium
     - node.type.playlist
+    - responsive_image.styles.details_cover
   module:
     - duration_field
-    - image
+    - responsive_image
     - text
     - user
 id: node.playlist.default
@@ -59,11 +59,11 @@ content:
     weight: 3
     region: content
   field_cover:
-    type: image
+    type: responsive_image
     label: hidden
     settings:
+      responsive_image_style: details_cover
       image_link: ''
-      image_style: medium
       image_loading:
         attribute: lazy
     third_party_settings: {  }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -38,10 +38,15 @@ module:
   field_ui: 0
   file: 0
   file_download: 0
+  file_mdm: 0
+  file_mdm_exif: 0
+  file_mdm_font: 0
   filter: 0
   gin_toolbar: 0
   help: 0
   image: 0
+  image_effects: 0
+  imagemagick: 0
   inline_entity_form: 0
   language: 0
   layout_builder: 0
@@ -73,6 +78,7 @@ module:
   serialization: 0
   shortcut: 0
   shortcutperrole: 0
+  sophron: 0
   structure_sync: 0
   system: 0
   tagify: 0

--- a/config/field.field.media.image.field_media_image.yml
+++ b/config/field.field.media.image.field_media_image.yml
@@ -25,7 +25,7 @@ default_value_callback: ''
 settings:
   handler: 'default:file'
   handler_settings: {  }
-  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_directory: covers
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''
@@ -35,7 +35,7 @@ settings:
   title_field: false
   title_field_required: false
   default_image:
-    uuid: null
+    uuid: ''
     alt: ''
     title: ''
     width: null

--- a/config/field.field.media.mp3_file.field_media_audio_file.yml
+++ b/config/field.field.media.mp3_file.field_media_audio_file.yml
@@ -20,7 +20,7 @@ default_value_callback: ''
 settings:
   handler: 'default:file'
   handler_settings: {  }
-  file_directory: '[current-user:display-name]'
+  file_directory: streaming
   file_extensions: 'mp3 wav aac'
   max_filesize: ''
   description_field: false

--- a/config/field.field.media.mp3_file.field_owner.yml
+++ b/config/field.field.media.mp3_file.field_owner.yml
@@ -1,0 +1,29 @@
+uuid: 8dfa0e72-79ba-48db-a2f4-01dfa6779ea4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_owner
+    - media.type.mp3_file
+    - taxonomy.vocabulary.reader
+id: media.mp3_file.field_owner
+field_name: field_owner
+entity_type: media
+bundle: mp3_file
+label: Owner
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      reader: reader
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.media.other_file.field_media_file.yml
+++ b/config/field.field.media.other_file.field_media_file.yml
@@ -20,7 +20,7 @@ default_value_callback: ''
 settings:
   handler: 'default:file'
   handler_settings: {  }
-  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_directory: other
   file_extensions: 'txt doc docx pdf zip m4b m4a wav'
   max_filesize: ''
   description_field: false

--- a/config/field.field.media.other_file.field_owner.yml
+++ b/config/field.field.media.other_file.field_owner.yml
@@ -1,0 +1,29 @@
+uuid: 7e1bb0af-8c77-450f-9354-311df6220769
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_owner
+    - media.type.other_file
+    - taxonomy.vocabulary.reader
+id: media.other_file.field_owner
+field_name: field_owner
+entity_type: media
+bundle: other_file
+label: Owner
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      reader: reader
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.work.field_cover.yml
+++ b/config/field.field.node.work.field_cover.yml
@@ -20,10 +20,10 @@ default_value_callback: ''
 settings:
   handler: 'default:file'
   handler_settings: {  }
-  file_directory: '[current-user:display-name]'
+  file_directory: covers
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '20 MB'
-  max_resolution: 600x600
+  max_resolution: 1600x1600
   min_resolution: 300x300
   alt_field: true
   alt_field_required: true

--- a/config/field.storage.media.field_media_image.yml
+++ b/config/field.storage.media.field_media_image.yml
@@ -18,10 +18,10 @@ type: image
 settings:
   target_type: file
   display_field: false
-  display_default: false
+  display_default: true
   uri_scheme: public
   default_image:
-    uuid: null
+    uuid: ''
     alt: ''
     title: ''
     width: null

--- a/config/field.storage.media.field_owner.yml
+++ b/config/field.storage.media.field_owner.yml
@@ -1,0 +1,20 @@
+uuid: e7a18df7-df56-41e6-a09b-9a29a8cf4fc7
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - taxonomy
+id: media.field_owner
+field_name: field_owner
+entity_type: media
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_cover.yml
+++ b/config/field.storage.node.field_cover.yml
@@ -13,7 +13,7 @@ type: image
 settings:
   target_type: file
   display_field: false
-  display_default: false
+  display_default: true
   uri_scheme: public
   default_image:
     uuid: ''

--- a/config/file.settings.yml
+++ b/config/file.settings.yml
@@ -5,7 +5,7 @@ description:
   length: 128
 icon:
   directory: core/modules/file/icons
-make_unused_managed_files_temporary: false
+make_unused_managed_files_temporary: true
 filename_sanitization:
   transliterate: true
   replace_whitespace: true

--- a/config/file_mdm.file_metadata_plugin.getimagesize.yml
+++ b/config/file_mdm.file_metadata_plugin.getimagesize.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: o53U_2I-21Es-9iqxeUMDRcRxN0spL1OiHuAVQhh2oI
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }

--- a/config/file_mdm.settings.yml
+++ b/config/file_mdm.settings.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: fOx6TBj_84WfX_a6JhuWiPQ-twAjHykvYsTvJAKbZsE
+metadata_cache:
+  enabled: true
+  expiration: 172800
+  disallowed_paths: {  }
+missing_file_log_level: 3

--- a/config/file_mdm_exif.file_metadata_plugin.exif.yml
+++ b/config/file_mdm_exif.file_metadata_plugin.exif.yml
@@ -1,0 +1,35 @@
+_core:
+  default_config_hash: u0ZqkNrnyVSnHXGBP0zlKY9dP1ZARzJZ9VSovzU_eDg
+ifd_map:
+  0:
+    type: 0
+    aliases:
+      - '0'
+      - IFD0
+      - Main
+  1:
+    type: 1
+    aliases:
+      - '1'
+      - IFD1
+      - Thumbnail
+  Exif:
+    type: 2
+    aliases:
+      - Exif
+  GPS:
+    type: 3
+    aliases:
+      - GPS
+  Interoperability:
+    type: 4
+    aliases:
+      - Interoperability
+      - Interop
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }

--- a/config/file_mdm_font.file_metadata_plugin.font.yml
+++ b/config/file_mdm_font.file_metadata_plugin.font.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: o53U_2I-21Es-9iqxeUMDRcRxN0spL1OiHuAVQhh2oI
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }

--- a/config/image.style.extra_extra_large.yml
+++ b/config/image.style.extra_extra_large.yml
@@ -13,3 +13,9 @@ effects:
       width: 1600
       height: 1600
       anchor: center-center
+  5c6e423b-3f30-43b6-840d-9bd8d4fba013:
+    uuid: 5c6e423b-3f30-43b6-840d-9bd8d4fba013
+    id: image_convert
+    weight: 2
+    data:
+      extension: jpeg

--- a/config/image.style.extra_extra_large.yml
+++ b/config/image.style.extra_extra_large.yml
@@ -1,0 +1,15 @@
+uuid: b3e20fe2-6132-4991-851c-942426513733
+langcode: en
+status: true
+dependencies: {  }
+name: extra_extra_large
+label: 'Extra Extra Large (1600x1600)'
+effects:
+  3d4eeb29-2172-4fb4-95e7-52082f6ec23e:
+    uuid: 3d4eeb29-2172-4fb4-95e7-52082f6ec23e
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 1600
+      height: 1600
+      anchor: center-center

--- a/config/image.style.extra_large_800x800.yml
+++ b/config/image.style.extra_large_800x800.yml
@@ -13,3 +13,9 @@ effects:
       width: 800
       height: 800
       anchor: center-center
+  5a94f204-876f-4076-8204-6ea7b8a39b84:
+    uuid: 5a94f204-876f-4076-8204-6ea7b8a39b84
+    id: image_convert
+    weight: 2
+    data:
+      extension: jpeg

--- a/config/image.style.large.yml
+++ b/config/image.style.large.yml
@@ -15,3 +15,9 @@ effects:
       width: 480
       height: 480
       upscale: false
+  0cc7f294-9a6e-4464-89d7-d4175be0d1c0:
+    uuid: 0cc7f294-9a6e-4464-89d7-d4175be0d1c0
+    id: image_convert
+    weight: 2
+    data:
+      extension: jpeg

--- a/config/image.style.medium.yml
+++ b/config/image.style.medium.yml
@@ -15,3 +15,9 @@ effects:
       width: 220
       height: 220
       upscale: false
+  30b8e8ea-894c-44cc-93ef-fdd93875131a:
+    uuid: 30b8e8ea-894c-44cc-93ef-fdd93875131a
+    id: image_convert
+    weight: 2
+    data:
+      extension: jpeg

--- a/config/image.style.original_aspect_ratio_mobile.yml
+++ b/config/image.style.original_aspect_ratio_mobile.yml
@@ -13,3 +13,9 @@ effects:
       width: 500
       height: null
       upscale: false
+  5be43d7c-8156-40ae-a41f-49b6885b91f0:
+    uuid: 5be43d7c-8156-40ae-a41f-49b6885b91f0
+    id: image_convert
+    weight: 2
+    data:
+      extension: jpeg

--- a/config/image.style.thumbnail.yml
+++ b/config/image.style.thumbnail.yml
@@ -15,3 +15,9 @@ effects:
       width: 100
       height: 100
       upscale: false
+  b745df04-2f29-45ca-9982-9f29908de16d:
+    uuid: b745df04-2f29-45ca-9982-9f29908de16d
+    id: image_convert
+    weight: 2
+    data:
+      extension: jpeg

--- a/config/image_effects.settings.yml
+++ b/config/image_effects.settings.yml
@@ -1,0 +1,14 @@
+_core:
+  default_config_hash: eaXmaPSud65p-XhTwMIL9vKETD9zR3qNOMMa5EUuoNw
+color_selector:
+  plugin_id: html_color
+  plugin_settings:
+    html_color: {  }
+image_selector:
+  plugin_id: basic
+  plugin_settings:
+    basic: {  }
+font_selector:
+  plugin_id: basic
+  plugin_settings:
+    basic: {  }

--- a/config/imagemagick.file_metadata_plugin.imagemagick_identify.yml
+++ b/config/imagemagick.file_metadata_plugin.imagemagick_identify.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: o53U_2I-21Es-9iqxeUMDRcRxN0spL1OiHuAVQhh2oI
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }

--- a/config/imagemagick.settings.yml
+++ b/config/imagemagick.settings.yml
@@ -1,0 +1,61 @@
+_core:
+  default_config_hash: ZsKMVk7NtJmc1hz4nl9k1DnxfytfS9qAoVBWT9fU_pY
+quality: 75
+binaries: imagemagick
+imagemagick_version: v6
+path_to_binaries: ''
+prepend: ''
+log_warnings: true
+debug: false
+advanced:
+  density: 0
+  colorspace: '0'
+  profile: ''
+  coalesce: false
+image_formats:
+  PNG:
+    mime_type: image/png
+  JPEG:
+    mime_type: image/jpeg
+  JPG:
+    mime_type: image/jpeg
+    weight: 10
+    enabled: false
+  GIF:
+    mime_type: image/gif
+  GIF87:
+    mime_type: image/gif
+    weight: 10
+    enabled: false
+  SVG:
+    mime_type: image/svg+xml
+    enabled: false
+  WEBP:
+    mime_type: image/webp
+  AVIF:
+    mime_type: image/avif
+  TIFF:
+    mime_type: image/tiff
+    enabled: false
+  PDF:
+    mime_type: application/pdf
+    enabled: false
+    identify_frames: '[0]'
+  HEIC:
+    mime_type: image/heif
+    enabled: false
+  BMP:
+    mime_type: image/x-ms-bmp
+    enabled: false
+  PSD:
+    mime_type: image/x-photoshop
+    enabled: false
+  WBMP:
+    mime_type: image/vnd.wap.wbmp
+    enabled: false
+  XBM:
+    mime_type: image/x-xbitmap
+    enabled: false
+  ICO:
+    mime_type: image/vnd.microsoft.icon
+    enabled: false

--- a/config/responsive_image.styles.details_cover.yml
+++ b/config/responsive_image.styles.details_cover.yml
@@ -3,9 +3,9 @@ langcode: en
 status: true
 dependencies:
   config:
+    - image.style.extra_extra_large
     - image.style.extra_large_800x800
     - image.style.large
-    - image.style.medium
     - image.style.original_aspect_ratio_mobile
   theme:
     - bootstrap_barrio_subtheme
@@ -14,12 +14,12 @@ label: 'Details Cover'
 image_style_mappings:
   -
     image_mapping_type: image_style
-    image_mapping: extra_large_800x800
+    image_mapping: extra_extra_large
     breakpoint_id: bootstrap_barrio_subtheme.xxlarge
     multiplier: 1x
   -
     image_mapping_type: image_style
-    image_mapping: large
+    image_mapping: extra_large_800x800
     breakpoint_id: bootstrap_barrio_subtheme.xlarge
     multiplier: 1x
   -
@@ -29,7 +29,7 @@ image_style_mappings:
     multiplier: 1x
   -
     image_mapping_type: image_style
-    image_mapping: medium
+    image_mapping: large
     breakpoint_id: bootstrap_barrio_subtheme.medium
     multiplier: 1x
   -

--- a/config/sophron.settings.yml
+++ b/config/sophron.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: kS--VUM7Yhfb5AIcnoXV8-JW90t-aIuQbzxPa1hbooU
+map_option: 0
+map_class: ''
+map_commands: {  }

--- a/config/system.file.yml
+++ b/config/system.file.yml
@@ -2,4 +2,4 @@ _core:
   default_config_hash: mguGHCYb9Dw5EcpfjwoShGV1Vjkbz3QuPRCLfxiye-g
 allow_insecure_uploads: false
 default_scheme: public
-temporary_maximum_age: 21600
+temporary_maximum_age: 2419200

--- a/config/ultimate_cron.job.aa_utils_cron.yml
+++ b/config/ultimate_cron.job.aa_utils_cron.yml
@@ -1,0 +1,29 @@
+uuid: eb35004f-5d4e-4334-b585-118fec8881ab
+langcode: en
+status: true
+dependencies:
+  module:
+    - aa_utils
+title: 'Default cron handler'
+id: aa_utils_cron
+weight: 0
+module: aa_utils
+callback: 'aa_utils#cron'
+scheduler:
+  id: simple
+  configuration:
+    rules:
+      - '* * * * *'
+launcher:
+  id: serial
+  configuration:
+    timeouts:
+      lock_timeout: 3600
+    launcher:
+      thread: 0
+logger:
+  id: database
+  configuration:
+    method: '3'
+    expire: 1209600
+    retain: 1000

--- a/config/user.role.archivist.yml
+++ b/config/user.role.archivist.yml
@@ -7,7 +7,6 @@ dependencies:
     - filter.format.legacy_work_html
     - media.type.mp3_file
     - media.type.other_file
-    - node.type.legacy_work
     - node.type.playlist
     - node.type.work
     - taxonomy.vocabulary.author
@@ -44,7 +43,6 @@ permissions:
   - 'access toolbar'
   - 'administer taxonomy'
   - 'cancel account'
-  - 'create legacy_work content'
   - 'create mp3_file media'
   - 'create other_file media'
   - 'create playlist content'
@@ -64,8 +62,6 @@ permissions:
   - 'create work content'
   - 'delete all taxonomy revisions'
   - 'delete media'
-  - 'delete own mp3_file media'
-  - 'delete own other_file media'
   - 'delete term revisions in author'
   - 'delete term revisions in category'
   - 'delete term revisions in cover_artist'
@@ -92,8 +88,6 @@ permissions:
   - 'delete terms in relationship'
   - 'delete terms in series'
   - 'delete terms in warning'
-  - 'edit own mp3_file media'
-  - 'edit own other_file media'
   - 'edit terms in author'
   - 'edit terms in category'
   - 'edit terms in cover_artist'

--- a/config/user.role.content_editor.yml
+++ b/config/user.role.content_editor.yml
@@ -7,7 +7,6 @@ dependencies:
     - filter.format.legacy_work_html
     - media.type.mp3_file
     - media.type.other_file
-    - node.type.legacy_work
     - node.type.playlist
     - node.type.work
     - taxonomy.vocabulary.author
@@ -33,7 +32,6 @@ permissions:
   - 'access contextual links'
   - 'access file download'
   - 'cancel account'
-  - 'create legacy_work content'
   - 'create mp3_file media'
   - 'create other_file media'
   - 'create playlist content'
@@ -44,10 +42,6 @@ permissions:
   - 'create terms in relationship'
   - 'create work content'
   - 'delete media'
-  - 'delete own mp3_file media'
-  - 'delete own other_file media'
-  - 'edit own mp3_file media'
-  - 'edit own other_file media'
   - 'update media'
   - 'use text format basic_html'
   - 'use text format legacy_work_html'

--- a/web/modules/custom/aa_search/src/Plugin/EntityReferenceSelection/SearchApiTermSelection.php
+++ b/web/modules/custom/aa_search/src/Plugin/EntityReferenceSelection/SearchApiTermSelection.php
@@ -25,7 +25,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
   id: "search_index:taxonomy_term",
   label: new TranslatableMarkup("Search API Taxonomy Term selection"),
   entity_types: ["taxonomy_term"],
-  group: "search_index",
+  group: "default",
   weight: 1
 )]
 class SearchApiTermSelection extends DefaultSelection {

--- a/web/modules/custom/aa_utils/src/Hook/AAUtilsHooks.php
+++ b/web/modules/custom/aa_utils/src/Hook/AAUtilsHooks.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\aa_utils\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+
+/**
+ * Class AAUtilsHooks defines hooks for the aa_utils module.
+ */
+class AAUtilsHooks {
+
+  /**
+   * Implements hook_cron().
+   *
+   * Defines a cron job which cleans up orphaned media/files.
+   */
+  #[Hook('cron')]
+  public function cron() {
+    /** @var \Drupal\media\MediaStorage $media_storage */
+    $media_storage = \Drupal::entityTypeManager()->getStorage('media');
+
+    $media_ids = $media_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->execute();
+    $media = $media_storage->loadMultiple($media_ids);
+  }
+
+}

--- a/web/modules/custom/audiofic_archive_rss/src/Hook/AudioficArchiveRssThemeHooks.php
+++ b/web/modules/custom/audiofic_archive_rss/src/Hook/AudioficArchiveRssThemeHooks.php
@@ -7,6 +7,7 @@ use Drupal\aa_utils\Service\AudioficTagUtils;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Link;
 use Drupal\file\Entity\File;
+use Drupal\image\Entity\ImageStyle;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Term;
@@ -206,7 +207,15 @@ class AudioficArchiveRssThemeHooks {
    */
   private function fetchCover(NodeInterface $node): NULL | string {
     $cover_field = $node->get('field_cover')->referencedEntities();
-    return count($cover_field) > 0 ? $cover_field[0]->createFileUrl() : NULL;
+    if (empty($cover_field)) {
+      return NULL;
+    }
+
+    // We use the extra_extra_large image style (1600x1600) to comply
+    // with apple podcast standards, see:
+    // https://podcasters.apple.com/support/5516-episode-art-template
+    $cover_image = $cover_field[0]->getFileUri();
+    return ImageStyle::load('extra_extra_large')->buildUrl($cover_image);
   }
 
   /**

--- a/web/modules/custom/audiofic_archive_rss/templates/views-view-audiofic-archive-rss.html.twig
+++ b/web/modules/custom/audiofic_archive_rss/templates/views-view-audiofic-archive-rss.html.twig
@@ -24,7 +24,7 @@
     <language>en</language>
     {% if options.is_contextual and contextual_filter == "node" %}
       {% if source_node.cover_url != NULL %}
-      <itunes:image href="https://{{ hostname }}{{ source_node.cover_url }}"/>
+      <itunes:image href="{{ source_node.cover_url }}"/>
       {% elseif options.cover_url|trim is not empty %}
       <itunes:image href="https://{{ hostname }}{{ options.cover_url }}"/>
       {% endif %}
@@ -61,7 +61,7 @@
           <itunes:explicit>{{ work.explicit ? 'true' : 'false' }}</itunes:explicit>
           <link>https://{{ hostname }}/{{ work.link }}</link>
           {% if work.cover_url != NULL %}
-          <itunes:image href="https://{{ hostname }}{{ work.cover_url }}" />
+          <itunes:image href="{{ work.cover_url }}" />
           {% endif %}
         </item>
       {% endfor %}

--- a/web/modules/custom/propagate_metadata/src/Hook/PropagateMetadataHooks.php
+++ b/web/modules/custom/propagate_metadata/src/Hook/PropagateMetadataHooks.php
@@ -3,8 +3,11 @@
 namespace Drupal\propagate_metadata\Hook;
 
 use Drupal\aa_utils\Service\AudioficUtils;
+use Drupal\Core\Access\AccessResultAllowed;
+use Drupal\Core\Access\AccessResultForbidden;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\media\MediaInterface;
 use Drupal\node\NodeInterface;
 use Drupal\user\Entity\User;
 
@@ -160,6 +163,36 @@ class PropagateMetadataHooks {
     }
 
     return $grants;
+  }
+
+  /**
+   * Implements hook_ENTITY_TYPE_access() for media.
+   *
+   * Used to define custom access based on the user's reader tag.
+   */
+  #[Hook('media_access')]
+  public function mediaAccess(MediaInterface $media, $operation, AccountInterface $account) {
+    $roles = $account->getRoles();
+
+    if (in_array('administrator', $roles)) {
+      return AccessResultAllowed::allowed();
+    } elseif (!in_array('content_editor', $roles)) {
+      return AccessResultForbidden::forbidden();
+    }
+
+    $user = User::load($account->id());
+    if (empty($user)) {
+      return AccessResultForbidden::forbidden();
+    }
+
+    $user_tags = array_column($user->get('field_reader_name')->getValue(), 'target_id');
+    $media_owners = array_column($media->get('field_owner')->getValue(), 'target_id');
+    foreach ($user_tags as $user_tag) {
+      if (in_array($user_tag, $media_owners)) {
+        return AccessResultAllowed::allowed();
+      }
+    }
+    return AccessResultForbidden::forbidden();
   }
 
 }

--- a/web/modules/custom/propagate_metadata/src/Hook/PropagateMetadataPresaveHooks.php
+++ b/web/modules/custom/propagate_metadata/src/Hook/PropagateMetadataPresaveHooks.php
@@ -17,12 +17,16 @@ use Drupal\user\Entity\User;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
- * Class PropagateMetadataNodePresaveHooks.
+ * Class PropagateMetadataPresaveHooks.
  *
- * Ensures that the work/legacy_work/playlist node types
- * have the correct data set when saved.
+ * Ensures that entities have the correct data set when
+ * saved. Manages the following entities:
+ * - node.work
+ * - node.playlist
+ * - node.legacy_work
+ * - media
  */
-class PropagateMetadataNodePresaveHooks {
+class PropagateMetadataPresaveHooks {
   use StringTranslationTrait;
 
   public function __construct(
@@ -49,6 +53,7 @@ class PropagateMetadataNodePresaveHooks {
         // propagated down to their related series?
         $this->enforceOwnerRules($node);
         $this->updateAllCollections($node, updated_duration_seconds: $duration);
+        $this->setMediaOwner($node);
         break;
 
       case 'legacy_work':
@@ -226,6 +231,21 @@ class PropagateMetadataNodePresaveHooks {
       ));
 
       $this->messenger->addError($this->t('You cannot remove other owners!'));
+    }
+  }
+
+  /**
+   * Updates all media entities attached to a node with the new owner(s).
+   */
+  private function setMediaOwner(NodeInterface $node) {
+    $streaming_files = $node->get('field_mp3_files')->referencedEntities();
+    $other_files = $node->get('field_other_files')->referencedEntities();
+    $owners = $node->get('field_owner')->referencedEntities();
+
+    /** @var \Drupal\media\MediaInterface $media */
+    foreach (array_merge($streaming_files, $other_files) as $media) {
+      $media->set('field_owner', $owners);
+      $media->save();
     }
   }
 

--- a/web/modules/custom/propagate_metadata/src/Hook/PropagateMetadataPresaveHooks.php
+++ b/web/modules/custom/propagate_metadata/src/Hook/PropagateMetadataPresaveHooks.php
@@ -87,6 +87,8 @@ class PropagateMetadataPresaveHooks {
    */
   #[Hook('node_delete')]
   public function nodeDelete(NodeInterface $node) {
+    $this->deleteMedia($node);
+
     if ($node->getType() !== 'work') {
       return;
     }
@@ -235,17 +237,47 @@ class PropagateMetadataPresaveHooks {
   }
 
   /**
+   * Fetches all media entities attached to a node (if any).
+   */
+  private function getAllMediaFromNode(NodeInterface $node): array {
+    $streaming_files = [];
+    $other_files = [];
+
+    if ($node->hasField('field_mp3_files')) {
+      $streaming_files = $node->get('field_mp3_files')->referencedEntities();
+    }
+
+    if ($node->hasField('field_other_files')) {
+      $other_files = $node->get('field_mp3_files')->referencedEntities();
+    }
+
+    return array_merge($streaming_files, $other_files);
+  }
+
+  /**
    * Updates all media entities attached to a node with the new owner(s).
    */
   private function setMediaOwner(NodeInterface $node) {
-    $streaming_files = $node->get('field_mp3_files')->referencedEntities();
-    $other_files = $node->get('field_other_files')->referencedEntities();
+    $all_media = $this->getAllMediaFromNode($node);
     $owners = $node->get('field_owner')->referencedEntities();
 
     /** @var \Drupal\media\MediaInterface $media */
-    foreach (array_merge($streaming_files, $other_files) as $media) {
+    foreach ($all_media as $media) {
       $media->set('field_owner', $owners);
       $media->save();
+    }
+  }
+
+  /**
+   * Deletes all referenced media from a node.
+   */
+  private function deleteMedia(NodeInterface $node) {
+    $all_media = $this->getAllMediaFromNode($node);
+
+    /** @var \Drupal\media\MediaInterface $media */
+    foreach ($all_media as $media) {
+      dpm('Deleting media!');
+      $media->delete();
     }
   }
 


### PR DESCRIPTION
closes: #18 

Media ownership is now governed by the owner field on the work it is attached to. This means that any owner of a work/series/legacy_work can update/delete media on that work even if they did not originally create it. The default permissions allowing editing/deleting your own media have been disabled so that if the original creator of a node gives up ownership they do not retain access to the media attached to that work.

When a node is deleted, there is a hook defined that ensures all media attached to it is deleted also.

The config of the files module has been changed so that when a file is not used anywhere (eg: when a media entity containing a file is deleted) the status of the file changes to "temporary". The file will then be automatically deleted after X N.O. days (currently set to 4 weeks, but we can adjust as necessary).

I have installed the image_effects module and configured all image styles that we use to convert images to jpegs in order to save on space - this does not effect the original image.