### PR TITLE
Alter user account deletion form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "drupal/metatag": "^2.1",
         "drupal/pathauto": "^1.13",
         "drupal/profile": "^1.11",
+        "drupal/queue_ui": "^3.2",
         "drupal/redirect": "^1.12",
         "drupal/rules": "^4.0",
         "drupal/search_api_solr": "^4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d41e22bd6fd98e1615afcc079432f88e",
+    "content-hash": "bf47c74f3fb87e8d4a3a5f7776160e69",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3353,6 +3353,90 @@
             "homepage": "https://drupal.org/project/profile",
             "support": {
                 "source": "https://git.drupalcode.org/project/profile"
+            }
+        },
+        {
+            "name": "drupal/queue_ui",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/queue_ui.git",
+                "reference": "3.2.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/queue_ui-3.2.3.zip",
+                "reference": "3.2.3",
+                "shasum": "320f7e3bf8390ed558a5127f33351c3efcc68dc7"
+            },
+            "require": {
+                "drupal/core": "^10.3 || ^11.0"
+            },
+            "require-dev": {
+                "drupal/queue_order": "^2",
+                "drush/drush": "^12.0 || ^13.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.2.3",
+                    "datestamp": "1766588442",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^12.0 || ^13.0"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "floretan",
+                    "homepage": "https://www.drupal.org/user/2743951",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "coltrane",
+                    "homepage": "https://www.drupal.org/user/91990",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "tsphethean",
+                    "homepage": "https://www.drupal.org/user/66163",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "bceyssens",
+                    "homepage": "https://www.drupal.org/user/2811585",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "voleger",
+                    "homepage": "https://www.drupal.org/user/881620",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "voleger",
+                    "homepage": "https://www.drupal.org/user/3260314"
+                }
+            ],
+            "description": "Interface and manager for Drupal queues.",
+            "homepage": "https://www.drupal.org/project/queue_ui",
+            "keywords": [
+                "drupal",
+                "php",
+                "queue"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/queue_ui",
+                "issues": "https://www.drupal.org/project/issues/queue_ui"
             }
         },
         {

--- a/config/core.entity_form_display.node.legacy_work.default.yml
+++ b/config/core.entity_form_display.node.legacy_work.default.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.legacy_work.field_rating
     - field.field.node.legacy_work.field_reader
     - field.field.node.legacy_work.field_relationship
+    - field.field.node.legacy_work.field_to_delete
     - field.field.node.legacy_work.field_warning
     - image.style.large
     - node.type.legacy_work
@@ -228,6 +229,7 @@ content:
 hidden:
   created: true
   field_legacy_series: true
+  field_to_delete: true
   langcode: true
   path: true
   promote: true

--- a/config/core.entity_form_display.node.legacy_work.limited_post_entry.yml
+++ b/config/core.entity_form_display.node.legacy_work.limited_post_entry.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.legacy_work.field_rating
     - field.field.node.legacy_work.field_reader
     - field.field.node.legacy_work.field_relationship
+    - field.field.node.legacy_work.field_to_delete
     - field.field.node.legacy_work.field_warning
     - image.style.thumbnail
     - node.type.legacy_work
@@ -134,4 +135,5 @@ hidden:
   field_owner: true
   field_rating: true
   field_relationship: true
+  field_to_delete: true
   field_warning: true

--- a/config/core.entity_view_display.node.legacy_work.default.yml
+++ b/config/core.entity_view_display.node.legacy_work.default.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.legacy_work.field_rating
     - field.field.node.legacy_work.field_reader
     - field.field.node.legacy_work.field_relationship
+    - field.field.node.legacy_work.field_to_delete
     - field.field.node.legacy_work.field_warning
     - node.type.legacy_work
     - responsive_image.styles.details_cover
@@ -155,6 +156,16 @@ content:
       link: true
     third_party_settings: {  }
     weight: 4
+    region: content
+  field_to_delete:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 122
     region: content
   field_warning:
     type: entity_reference_label

--- a/config/core.entity_view_display.node.legacy_work.full.yml
+++ b/config/core.entity_view_display.node.legacy_work.full.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.legacy_work.field_rating
     - field.field.node.legacy_work.field_reader
     - field.field.node.legacy_work.field_relationship
+    - field.field.node.legacy_work.field_to_delete
     - field.field.node.legacy_work.field_warning
     - node.type.legacy_work
     - responsive_image.styles.details_cover
@@ -112,6 +113,7 @@ hidden:
   field_format: true
   field_legacy_series: true
   field_owner: true
+  field_to_delete: true
   field_warning: true
   flag_bookmark: true
   flag_to_listen: true

--- a/config/core.entity_view_display.node.legacy_work.teaser.yml
+++ b/config/core.entity_view_display.node.legacy_work.teaser.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.legacy_work.field_rating
     - field.field.node.legacy_work.field_reader
     - field.field.node.legacy_work.field_relationship
+    - field.field.node.legacy_work.field_to_delete
     - field.field.node.legacy_work.field_warning
     - node.type.legacy_work
     - responsive_image.styles.teaser_cover
@@ -91,6 +92,7 @@ hidden:
   field_legacy_series: true
   field_length: true
   field_owner: true
+  field_to_delete: true
   field_warning: true
   langcode: true
   links: true

--- a/config/core.entity_view_display.node.legacy_work.teaser_full.yml
+++ b/config/core.entity_view_display.node.legacy_work.teaser_full.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.legacy_work.field_rating
     - field.field.node.legacy_work.field_reader
     - field.field.node.legacy_work.field_relationship
+    - field.field.node.legacy_work.field_to_delete
     - field.field.node.legacy_work.field_warning
     - node.type.legacy_work
     - responsive_image.styles.teaser_cover
@@ -126,6 +127,7 @@ hidden:
   field_category: true
   field_duration: true
   field_owner: true
+  field_to_delete: true
   field_warning: true
   flag_bookmark: true
   flag_to_listen: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -69,6 +69,7 @@ module:
   phpass: 0
   profile: 0
   propagate_metadata: 0
+  queue_ui: 0
   redirect: 0
   responsive_image: 0
   rules: 0

--- a/config/field.field.node.legacy_work.field_to_delete.yml
+++ b/config/field.field.node.legacy_work.field_to_delete.yml
@@ -1,0 +1,21 @@
+uuid: 59df9a45-8e96-43d8-8009-f640e93e6976
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_to_delete
+    - node.type.legacy_work
+id: node.legacy_work.field_to_delete
+field_name: field_to_delete
+entity_type: node
+bundle: legacy_work
+label: 'To Delete'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/field.storage.node.field_to_delete.yml
+++ b/config/field.storage.node.field_to_delete.yml
@@ -1,0 +1,18 @@
+uuid: b175379e-b2cf-4308-9b64-745c41ff982f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_to_delete
+field_name: field_to_delete
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/views.view.content.yml
+++ b/config/views.view.content.yml
@@ -465,6 +465,52 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
+        field_to_delete_value:
+          id: field_to_delete_value
+          table: node__field_to_delete
+          field: field_to_delete_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Legacy Work To Delete'
+            description: ''
+            use_operator: false
+            operator: field_to_delete_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_to_delete_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: true
+          group_info:
+            label: 'Legacy Works To Delete'
+            description: ''
+            identifier: field_to_delete_value
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: 'True'
+                operator: '='
+                value: '1'
+              2:
+                title: 'False'
+                operator: empty
+                value: '1'
       filter_groups:
         operator: AND
         groups:

--- a/web/modules/custom/aa_gin/aa_gin.services.yml
+++ b/web/modules/custom/aa_gin/aa_gin.services.yml
@@ -1,0 +1,9 @@
+services:
+  aa_gin.route_subscriber:
+    class: Drupal\aa_gin\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }
+
+  logger.channel.delete_account_audit_log:
+    parent: logger.channel_base
+    arguments: [ 'delete_account_audit_log' ]

--- a/web/modules/custom/aa_gin/src/Form/UserCancelForm.php
+++ b/web/modules/custom/aa_gin/src/Form/UserCancelForm.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Drupal\aa_gin\Form;
+
+use Drupal\Core\Batch\BatchBuilder;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Url;
+use Drupal\node\Entity\Node;
+use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Custom form to handle cancelling user accounts.
+ */
+class UserCancelForm extends FormBase {
+
+  /**
+   * The user to delete the account of.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * The Entity Type Manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The Queue service.
+   *
+   * @var \Drupal\Core\Queue\QueueFactory
+   */
+  protected $queueFactory;
+
+  public function __construct(EntityTypeManager $entity_type_manager, QueueFactory $queue_factory) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->queueFactory = $queue_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('queue'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(
+    array $form,
+    FormStateInterface $form_state,
+    ?UserInterface $user = NULL,
+  ) {
+    if (empty($user)) {
+      throw new \Exception('User not provided');
+    }
+    $this->user = $user;
+    $triggering_elem = $form_state->getTriggeringElement();
+    if ($triggering_elem && $triggering_elem['#id'] == 'edit-cancel') {
+      $response = new RedirectResponse(Url::fromRoute('entity.user.canonical', ['user' => $user->id()])->toString());
+      $response->send();
+    }
+
+    $form['tag_note'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('Orphaning your attribution tags impacts all three types: reader, author and cover artist tags.'),
+    ];
+
+    $form['user_cancel_method'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('When deleting my account'),
+      '#required' => TRUE,
+      '#options' => [
+        'delete' => $this->t('Delete my account & delete all works & series I own, permanently removing the attached podfic files from the archive. Works that I do not own but am attributed on will have my user tag removed and replaced with the orphan-account tag. This action cannot be undone and <b>will</b> affect works with co-owners.'),
+        'orphan' => $this->t('Delete my account but retain all works I own. Any works I am attributed on will have my user tag changed to the anonymous orphan-account. This action cannot be undone.'),
+        'abandon' => $this->t('Delete my account but retain all works I own. My attribution on those works will remain unchanged. If I want to recreate my account in the future, I will be able to claim these works again.'),
+      ],
+    ];
+
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Confirm'),
+    ];
+
+    $form['cancel'] = [
+      '#type' => 'button',
+      '#value' => $this->t('Cancel'),
+      // Ensure this button functions, even if there are validation issues.
+      '#limit_validation_errors' => [],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $cancel_method = $form_state->getValue('user_cancel_method');
+    if ($cancel_method == 'delete') {
+      $this->deleteOwnedContent();
+    }
+
+    if ($cancel_method == 'delete' || $cancel_method == 'orphan') {
+      $this->attributeToOrphanTag();
+    }
+
+    $this->makeNodeAuthorAnonymous();
+    $form_state->setRedirect('<front>');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'user_cancel_form';
+  }
+
+  /**
+   * Queue every work & series this user owns for deletion.
+   *
+   * Legacy works are unpublished and marked for manual deletion
+   * by archivists - since the files are not deletable by drupal.
+   */
+  private function deleteOwnedContent() {
+    $user_tags = array_column($this->user->get('field_reader_name')->getValue(), 'target_id');
+
+    /** @var \Drupal\node\NodeStorage $node_storage */
+    $node_storage = $this->entityTypeManager->getStorage('node');
+
+    $works_queue = $this->queueFactory->get('queue_cancel_account_delete_nodes');
+    $works_and_series = $node_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', ['work', 'playlist'], 'IN')
+      ->condition('field_owner.entity:taxonomy_term.tid', $user_tags, 'IN')
+      ->execute();
+    foreach ($works_and_series as $nid) {
+      $works_queue->createItem($nid);
+    }
+
+    $legacy_works_queue = $this->queueFactory->get('queue_cancel_account_delete_legacy_works');
+    $legacy_works = $node_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'legacy_work')
+      ->condition('field_owner.entity:taxonomy_term.tid', $user_tags, 'IN')
+      ->execute();
+    foreach ($legacy_works as $nid) {
+      $legacy_works_queue->createItem($nid);
+    }
+  }
+
+  /**
+   * Transfer authorship of all nodes created by this user to anonymous.
+   */
+  private function makeNodeAuthorAnonymous() {
+    /** @var \Drupal\node\NodeStorage $node_storage */
+    $node_storage = $this->entityTypeManager->getStorage('node');
+    $nodes = $node_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('uid', $this->user->id())
+      ->execute();
+
+    $batch = new BatchBuilder();
+    $batch->setTitle('Running batch process.')
+      ->setFinishCallback([self::class, 'batchFinished'])
+      ->setInitMessage('Starting')
+      ->setProgressMessage('Processing...')
+      ->setErrorMessage('An error occured while deleting your account. Please contact an administrator so that we can sort things out for you!');
+
+    foreach (array_chunk($nodes, 10) as $node_chunk) {
+      $batch->addOperation([self::class, 'batchProcess'], [$this->user->id(), $node_chunk]);
+    }
+    batch_set($batch->toArray());
+  }
+
+  /**
+   * Callback which processes part of the user deletion batch job.
+   */
+  public static function batchProcess($uid, array $nodes, array &$context) {
+    if (!isset($context['sandbox']['progress'])) {
+      $context['sandbox']['progress'] = 0;
+      $context['results']['uid'] = $uid;
+    }
+
+    foreach (Node::loadMultiple($nodes) as $node) {
+      $node->setOwnerId(0);
+      $node->save();
+    }
+
+    $context['results']['progress'] += count($nodes);
+  }
+
+  /**
+   * Callback that runs after user deletion batch job finishes.
+   */
+  public static function batchFinished(bool $success, array $results, array $operations, string $elapsed) {
+    $messenger = \Drupal::messenger();
+    if ($success) {
+      $user = User::load($results['uid']);
+      if (!empty($user)) {
+        $user->delete();
+      }
+
+      $messenger->addMessage(t('Ensured @count works were separated from your account before deleting it in @elapsed. If you asked to orphan or delete works there may be some lag time while the system processes each of your works - especially if you asked to delete legacy works since this is a manual process. Please do contact an administrator if the deletion is taking unreasonably long, we are always happy to double check and ensure that everything has been deleted correctly.', [
+        '@count' => $results['progress'],
+        '@elapsed' => $elapsed,
+      ]));
+      \Drupal::logger('batch_user_delete')->info('Assigned @count works to the anonymous user before deleting the user with id @uid in @elapsed.', [
+        '@count' => $results['progress'],
+        '@uid' => $results['uid'],
+        '@elapsed' => $elapsed,
+      ]);
+    } else {
+      $messenger->addError(t('An error occured while deleting your account! Please contact an administrator so that we can ensure your account is deleted correctly.'));
+    }
+  }
+
+  /**
+   * Queue all attributions to be converted to the orphan-account tag.
+   *
+   * After doing this, delete each of the user's attribution
+   * tags.
+   */
+  private function attributeToOrphanTag() {
+    $queue = $this->queueFactory->get('queue_cancel_account_orphan_works');
+
+    $reader_tags = array_column($this->user->get('field_reader_name')->getValue(), 'target_id');
+    $author_tags = array_column($this->user->get('field_author_name')->getValue(), 'target_id');
+    $cover_artist_tags = array_column($this->user->get('field_cover_artist_name')->getValue(), 'target_id');
+
+    foreach ($reader_tags as $tid) {
+      $queue->createItem(['tid' => $tid, 'vid' => 'reader']);
+    }
+    foreach ($author_tags as $tid) {
+      $queue->createItem(['tid' => $tid, 'vid' => 'author']);
+    }
+    foreach ($cover_artist_tags as $tid) {
+      $queue->createItem(['tid' => $tid, 'vid' => 'cover_artist']);
+    }
+  }
+
+}

--- a/web/modules/custom/aa_gin/src/Hook/AAGinHooks.php
+++ b/web/modules/custom/aa_gin/src/Hook/AAGinHooks.php
@@ -29,7 +29,6 @@ class AAGinHooks {
     ])) {
       $attachments['#attached']['library'][] = 'aa_gin/content-form';
     }
-
   }
 
 }

--- a/web/modules/custom/aa_gin/src/Plugin/QueueWorker/DeleteNodesQueueWorker.php
+++ b/web/modules/custom/aa_gin/src/Plugin/QueueWorker/DeleteNodesQueueWorker.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\aa_gin\Plugin\QueueWorker;
+
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Queue worker for the queue_cancel_account_delete_nodes.
+ *
+ * Deletes works and playlists.
+ *
+ * @QueueWorker(
+ *   id = "queue_cancel_account_delete_nodes",
+ *   title = @Translation("Queue worker that deletes works & playlists after an account is deleted."),
+ *   cron = {"time" = 60}
+ * )
+ */
+class DeleteNodesQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+  use StringTranslationTrait;
+
+  /**
+   * Logger factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * The Entity Type Manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, LoggerChannelInterface $logger, EntityTypeManager $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->logger = $logger;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('logger.channel.delete_account_audit_log'),
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    $node = $this->entityTypeManager->getStorage('node')->load($data);
+    $node->delete();
+    $this->logger->info($this->t('Deleted node with id @id', ['@id' => $data]));
+  }
+
+}

--- a/web/modules/custom/aa_gin/src/Plugin/QueueWorker/MarkLegacyWorksForDeletionQueueWorker.php
+++ b/web/modules/custom/aa_gin/src/Plugin/QueueWorker/MarkLegacyWorksForDeletionQueueWorker.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\aa_gin\Plugin\QueueWorker;
+
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Queue worker for the queue_cancel_account_delete_legacy_works.
+ *
+ * Marks legacy works for deletion.
+ *
+ * @QueueWorker(
+ *   id = "queue_cancel_account_delete_legacy_works",
+ *   title = @Translation("Queue worker that marks legacy works for deletion after an account is deleted."),
+ *   cron = {"time" = 60}
+ * )
+ */
+class MarkLegacyWorksForDeletionQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+  use StringTranslationTrait;
+
+  /**
+   * Logger factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * The Entity Type Manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, LoggerChannelInterface $logger, EntityTypeManager $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->logger = $logger;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('logger.channel.delete_account_audit_log'),
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $this->entityTypeManager->getStorage('node')->load($data);
+    $node->setUnpublished();
+    $node->set('field_to_delete', TRUE);
+    $node->save();
+
+    $this->logger->info($this->t('Marked legacy work with id @id for deletion', ['@id' => $data]));
+  }
+
+}

--- a/web/modules/custom/aa_gin/src/Plugin/QueueWorker/OrphanWorksQueueWorker.php
+++ b/web/modules/custom/aa_gin/src/Plugin/QueueWorker/OrphanWorksQueueWorker.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Drupal\aa_gin\Plugin\QueueWorker;
+
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Queue worker for the queue_cancel_account_orphan_works.
+ *
+ * Replaces attribution tags with the orphan_account tag & deletes them.
+ *
+ * @QueueWorker(
+ *   id = "queue_cancel_account_orphan_works",
+ *   title = @Translation("Queue worker that replaces attribution tags with the orphan_account tag after an account is deleted."),
+ *   cron = {"time" = 60}
+ * )
+ */
+class OrphanWorksQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+  use StringTranslationTrait;
+
+  protected const ORPHAN_ACCOUNT_ID = [
+    'reader' => 18383,
+    'author' => 9287,
+    // TODO: Will need to be updated on site launch!
+    'cover_artist' => 22793,
+  ];
+
+  /**
+   * Logger factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * The Entity Type Manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, LoggerChannelInterface $logger, EntityTypeManager $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->logger = $logger;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('logger.channel.delete_account_audit_log'),
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    $tid = $data['tid'];
+    $vid = $data['vid'];
+
+    /** @var \Drupal\taxonomy\TermStorage $term_storage */
+    $term_storage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $orphan_account = $term_storage->load($this::ORPHAN_ACCOUNT_ID[$vid]);
+
+    /** @var \Drupal\node\NodeStorage $node_storage */
+    $node_storage = $this->entityTypeManager->getStorage('node');
+    $query = $node_storage->getQuery()->accessCheck(FALSE);
+    $group = $query->orConditionGroup();
+    switch ($vid) {
+      case 'reader':
+        $group->condition('field_owner.entity:taxonomy_term.tid', $tid);
+        $group->condition('field_reader.entity:taxonomy_term.tid', $tid);
+        break;
+
+      case 'author':
+        $group->condition('field_author.entity:taxonomy_term.tid', $tid);
+        break;
+
+      case 'cover_artist':
+        $group->condition('field_cover_artist.entity:taxonomy_term.tid', $tid);
+        break;
+    }
+    $nodes = $query->condition($group)->execute();
+
+    /** @var \Drupal\node\NodeInterface $node */
+    foreach ($node_storage->loadMultiple($nodes) as $node) {
+      switch ($vid) {
+        case 'reader':
+          $this->removeFieldAttribution($tid, $node, 'field_owner', $orphan_account);
+          $this->removeFieldAttribution($tid, $node, 'field_reader', $orphan_account);
+          break;
+
+        case 'author':
+          $this->removeFieldAttribution($tid, $node, 'field_author', $orphan_account);
+          break;
+
+        case 'cover_artist':
+          $this->removeFieldAttribution($tid, $node, 'field_cover_artist', $orphan_account);
+          break;
+      }
+      $node->save();
+      $this->logger->info($this->t('Removed attribution tag with tid @tid from node with nid @nid',
+                                   ['@tid' => $tid, '@nid' => $node->id()]));
+    }
+
+    $term = $term_storage->load($tid);
+    $term->delete();
+    $this->logger->info($this->t('Deleted attribution tag with tid @tid', ['@tid' => $tid]));
+  }
+
+  /**
+   * Replaces any user attributions with the orphan_account.
+   *
+   * If the user is not attributed in this field, does nothing.
+   */
+  private function removeFieldAttribution($tid, NodeInterface $node, string $field_name, TermInterface $orphan_account) {
+    $current_tags = $node->get($field_name)->referencedEntities();
+    $updated_tags = [];
+    $add_orphan_account = FALSE;
+
+    foreach ($current_tags as $tag) {
+      if ($tag->id() == $tid) {
+        $add_orphan_account = TRUE;
+        continue;
+      }
+      $updated_tags[] = $tag;
+    }
+    if (!$add_orphan_account) {
+      return;
+    }
+
+    $updated_tags[] = $orphan_account;
+    $node->set($field_name, $updated_tags);
+  }
+
+}

--- a/web/modules/custom/aa_gin/src/Routing/RouteSubscriber.php
+++ b/web/modules/custom/aa_gin/src/Routing/RouteSubscriber.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\aa_gin\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to dynamic route events to override the user cancel route.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+
+    if ($route = $collection->get('entity.user.cancel_form')) {
+      $route->setDefault('_title', 'Are you sure you want to delete your account?');
+      $route->setDefault('_form', '\Drupal\aa_gin\Form\UserCancelForm');
+    }
+
+  }
+
+}

--- a/web/modules/custom/propagate_metadata/src/Hook/PropagateMetadataPresaveHooks.php
+++ b/web/modules/custom/propagate_metadata/src/Hook/PropagateMetadataPresaveHooks.php
@@ -276,7 +276,6 @@ class PropagateMetadataPresaveHooks {
 
     /** @var \Drupal\media\MediaInterface $media */
     foreach ($all_media as $media) {
-      dpm('Deleting media!');
       $media->delete();
     }
   }


### PR DESCRIPTION
closes: #41 

Overrides the default account deletion form with our custom logic. Assigning a user's works to the guest user is handled as a batch job immediately. The optional extra work of deleting works/series, marking legacy works for deletion & orphaning attributed works is entered into the drupal task queue to be processed in the background.